### PR TITLE
Extract AT modem

### DIFF
--- a/examples/TwilioTests/OwlCLI/OwlCLI.ino
+++ b/examples/TwilioTests/OwlCLI/OwlCLI.ino
@@ -112,7 +112,7 @@ void loop() {
   cli_resume = owlModemCLI->handleUserInput(cli_resume);
 
   /* Take care of async modem events */
-  owlModem->handleRxOnTimer();
+  owlModem->AT.spin();
   /* Important step - handling UDP data */
   owlModem->socket.handleWaitingData();
 

--- a/openocd.cfg
+++ b/openocd.cfg
@@ -1,0 +1,7 @@
+# openocd setup for J-Link interface
+
+source [find interface/jlink.cfg]
+
+transport select swd
+
+source [find target/stm32f4x.cfg]

--- a/src/BreakoutSDK/Breakout.cpp
+++ b/src/BreakoutSDK/Breakout.cpp
@@ -384,7 +384,7 @@ void Breakout::spin() {
   if (next_polling != 0 && next_polling <= owl_time()) checkForCommands();
 
   /* Take care of async modem events */
-  owlModem->handleRxOnTimer();
+  owlModem->AT.spin();
 
   /* Take care of UDP/TCP data from the modem */
   owlModem->socket.handleWaitingData();

--- a/src/BreakoutSDK/Breakout.cpp
+++ b/src/BreakoutSDK/Breakout.cpp
@@ -79,8 +79,8 @@ void Breakout::setPollingInterval(uint32_t interval_seconds) {
   } else if (interval_seconds == 0) {
     polling_interval = 0;
   } else {
-    LOG(L_WARN, "Interval %u seconds less than minimum of %u but not 0. Using minimum polling interval.\r\n", interval_seconds,
-        BREAKOUT_POLLING_INTERVAL_MINIMUM);
+    LOG(L_WARN, "Interval %u seconds less than minimum of %u but not 0. Using minimum polling interval.\r\n",
+        interval_seconds, BREAKOUT_POLLING_INTERVAL_MINIMUM);
     polling_interval = BREAKOUT_POLLING_INTERVAL_MINIMUM;
   }
 
@@ -395,7 +395,7 @@ void Breakout::spin() {
 #if TESTING_WITH_CLI == 1
   /* Enable also CLI, for intermediary testing */
   if (!owlModemCLI) owlModemCLI = owl_new OwlModemCLI(owlModem, &SerialDebugPort);
-  cli_resume                    = owlModemCLI->handleUserInput(cli_resume);
+  cli_resume = owlModemCLI->handleUserInput(cli_resume);
 #endif
 }
 
@@ -627,7 +627,7 @@ recovered_connection:
 
   CoAPMessage request = CoAPMessage(CoAP_Type__Confirmable, CoAP_Code_Class__Request, CoAP_Code_Detail__Request__POST,
                                     coapPeer->getNextMessageId());
-  request.token = coapPeer->getNextToken(&request.token_length);
+  request.token       = coapPeer->getNextToken(&request.token_length);
   if (!request.addOptionUriPath("v1")) {
     LOG(L_ERR, "Error adding UriPath\r\n");
     goto error;
@@ -665,7 +665,7 @@ recovered_connection:
 error:
   /* Reset the polling interval - doesn't matter if this was called manually or on interval
    * - after error label, to avoid hammering this on errors */
-  last_polling                        = now;
+  last_polling = now;
   if (next_polling != 0) next_polling = now + polling_interval * 1000;
 
   request.destroy();
@@ -722,7 +722,7 @@ bool Breakout::getGNSSData(gnss_data_t *out_gnss_data) {
 
 
 void Breakout::notifyConnectionStatusChanged() {
-  connection_status_e status                                                           = getConnectionStatus();
+  connection_status_e status = getConnectionStatus();
   if (status == CONNECTION_STATUS_REGISTERED_AND_CONNECTED) last_coap_status_connected = owl_time();
   if (connection_handler) (connection_handler)(status);
 }

--- a/src/BreakoutSDK/Breakout.h
+++ b/src/BreakoutSDK/Breakout.h
@@ -34,7 +34,7 @@
 
 
 #define MAX_PENDING_COMMANDS 100
-#define BREAKOUT_POLLING_INTERVAL_MINIMUM 60 // Temporary minimum interval; expect this to be 10 minutes in the future.
+#define BREAKOUT_POLLING_INTERVAL_MINIMUM 60  // Temporary minimum interval; expect this to be 10 minutes in the future.
 #define BREAKOUT_INIT_CONNECTION_TIMEOUT 60
 #define BREAKOUT_INIT_CONNECTION_RETRIES 2
 #define BREAKOUT_REINIT_CONNECTION_INTERVAL 600
@@ -379,7 +379,7 @@ class Breakout {
   uint32_t polling_interval = 10 * 60; /**< Polling interval in seconds */
   owl_time_t last_polling   = 0;       /**< Time of last polling - will warn if manually triggering it more often */
   owl_time_t next_polling   = 1;       /**< Time of next automatic polling, or 0 if disabled. Initialize to 0 if to
-                                         * disable it, or 1 if to enable it by default, without setting the poll. */
+                                        * disable it, or 1 if to enable it by default, without setting the poll. */
   coap_token_t last_polling_token = 0; /**< Token sent in the last Heartbeats request, to match the Response */
   uint64_t queued_command_count   = 0; /**< Last received Queued-Command-Count, as a Response to Heartbeats */
 

--- a/src/BreakoutSDK/Breakout.h
+++ b/src/BreakoutSDK/Breakout.h
@@ -27,7 +27,6 @@
 #include "CLI/OwlModemCLI.h"
 
 
-
 #define TESTING_WITH_DTLS 1
 
 #define TESTING_WITH_CLI 1

--- a/src/BreakoutSDK/CLI/OwlModemCLI.cpp
+++ b/src/BreakoutSDK/CLI/OwlModemCLI.cpp
@@ -127,13 +127,13 @@ class RawGNSSBypass : public OwlModemCLIExecutor {
 class PowerOn : public OwlModemCLIExecutor {
  public:
   PowerOn()
-      : OwlModemCLIExecutor("powerOn", "<module_bitmask>",
-                            "Power on modules - 1 modem, 2 Grove, 4 RGBLED, 8 GNSS\r\n", 1, 1) {
+      : OwlModemCLIExecutor("powerOn", "<module_bitmask>", "Power on modules - 1 modem, 2 Grove, 4 RGBLED, 8 GNSS\r\n",
+                            1, 1) {
   }
 
   void executor(OwlModemCLI &cli, OwlModemCLICommand &cmd) {
-    owl_power_m bit_mask = (owl_power_m) 0;
-    bit_mask = (owl_power_m)str_to_uint32_t(cmd.argv[0], 10);
+    owl_power_m bit_mask = (owl_power_m)0;
+    bit_mask             = (owl_power_m)str_to_uint32_t(cmd.argv[0], 10);
     cli.owlModem->powerOn(bit_mask);
   }
 };
@@ -143,13 +143,13 @@ class PowerOn : public OwlModemCLIExecutor {
 class PowerOff : public OwlModemCLIExecutor {
  public:
   PowerOff()
-      : OwlModemCLIExecutor("powerOff", "<module_bitmask>",
-                            "Power on modules - 1 modem, 2 Grove, 4 RGBLED, 8 GNSS\r\n", 1, 1) {
+      : OwlModemCLIExecutor("powerOff", "<module_bitmask>", "Power on modules - 1 modem, 2 Grove, 4 RGBLED, 8 GNSS\r\n",
+                            1, 1) {
   }
 
   void executor(OwlModemCLI &cli, OwlModemCLICommand &cmd) {
-    owl_power_m bit_mask = (owl_power_m) 0;
-    bit_mask = (owl_power_m) str_to_uint32_t(cmd.argv[0], 10);
+    owl_power_m bit_mask = (owl_power_m)0;
+    bit_mask             = (owl_power_m)str_to_uint32_t(cmd.argv[0], 10);
     cli.owlModem->powerOff(bit_mask);
   }
 };
@@ -394,8 +394,8 @@ class SetModemFunctionality : public OwlModemCLIExecutor {
   }
 
   void executor(OwlModemCLI &cli, OwlModemCLICommand &cmd) {
-    at_cfun_fun_e fun      = (at_cfun_fun_e)str_to_long_int(cmd.argv[0], 10);
-    at_cfun_rst_e rst      = AT_CFUN__RST__No_Modem_Reset;
+    at_cfun_fun_e fun = (at_cfun_fun_e)str_to_long_int(cmd.argv[0], 10);
+    at_cfun_rst_e rst = AT_CFUN__RST__No_Modem_Reset;
     if (cmd.argc >= 2) rst = (at_cfun_rst_e)str_to_long_int(cmd.argv[1], 10);
     if (cli.owlModem->network.setModemFunctionality(fun, cmd.argc >= 2 ? &rst : 0)) {
       LOGF(L_CLI, "OK fun=%d(%s) rst=%d(%s)\r\n", fun, at_cfun_fun_text(fun), rst, at_cfun_rst_text(rst));
@@ -475,13 +475,13 @@ class SetOperatorSelection : public OwlModemCLIExecutor {
   }
 
   void executor(OwlModemCLI &cli, OwlModemCLICommand &cmd) {
-    at_cops_mode_e mode       = (at_cops_mode_e)str_to_long_int(cmd.argv[0], 10);
-    at_cops_format_e format   = AT_COPS__Format__Long_Alphanumeric;
-    str oper                  = {0};
-    at_cops_act_e act         = AT_COPS__Access_Technology__LTE_NB_S1;
+    at_cops_mode_e mode     = (at_cops_mode_e)str_to_long_int(cmd.argv[0], 10);
+    at_cops_format_e format = AT_COPS__Format__Long_Alphanumeric;
+    str oper                = {0};
+    at_cops_act_e act       = AT_COPS__Access_Technology__LTE_NB_S1;
     if (cmd.argc >= 2) format = (at_cops_format_e)str_to_long_int(cmd.argv[1], 10);
-    if (cmd.argc >= 3) oper   = cmd.argv[2];
-    if (cmd.argc >= 4) act    = (at_cops_act_e)str_to_long_int(cmd.argv[3], 10);
+    if (cmd.argc >= 3) oper = cmd.argv[2];
+    if (cmd.argc >= 4) act = (at_cops_act_e)str_to_long_int(cmd.argv[3], 10);
     if (cli.owlModem->network.setOperatorSelection(mode, cmd.argc >= 2 ? &format : 0, cmd.argc >= 3 ? &oper : 0,
                                                    cmd.argc >= 4 ? &act : 0)) {
       LOGF(L_CLI, "OK mode=%d(%s) format=%d(%s) oper=[%.*s] act=%d(%.*s)\r\n", mode, at_cops_mode_text(mode), format,
@@ -669,7 +669,7 @@ class GetAPNIPAddress : public OwlModemCLIExecutor {
   }
 
   void executor(OwlModemCLI &cli, OwlModemCLICommand &cmd) {
-    uint8_t cid            = 1;
+    uint8_t cid = 1;
     if (cmd.argc >= 1) cid = (uint8_t)str_to_uint32_t(cmd.argv[0], 10);
     uint8_t ipv4[4];
     uint8_t ipv6[16];
@@ -695,9 +695,9 @@ class OpenSocket : public OwlModemCLIExecutor {
   }
 
   void executor(OwlModemCLI &cli, OwlModemCLICommand &cmd) {
-    at_uso_protocol_e protocol    = (at_uso_protocol_e)str_to_uint32_t(cmd.argv[0], 10);
-    uint16_t local_port           = 0;
-    uint8_t out_socket            = 0;
+    at_uso_protocol_e protocol = (at_uso_protocol_e)str_to_uint32_t(cmd.argv[0], 10);
+    uint16_t local_port        = 0;
+    uint8_t out_socket         = 0;
     if (cmd.argc >= 2) local_port = (int)str_to_long_int(cmd.argv[1], 10);
     if (cli.owlModem->socket.open(protocol, local_port, &out_socket))
       LOGF(L_CLI, "OK socket=%u\r\n", out_socket);
@@ -773,7 +773,7 @@ class SendUDP : public OwlModemCLIExecutor {
       return;
     }
     char buf[512];
-    str data = {.s = buf, .len = 0};
+    str data           = {.s = buf, .len = 0};
     data.len           = hex_to_str(data.s, 512, cmd.argv[1]);
     int out_bytes_sent = 0;
     if (cli.owlModem->socket.sendUDP(socket, data, &out_bytes_sent))
@@ -798,7 +798,7 @@ class SendTCP : public OwlModemCLIExecutor {
       return;
     }
     char buf[512];
-    str data = {.s = buf, .len = 0};
+    str data           = {.s = buf, .len = 0};
     data.len           = hex_to_str(data.s, 512, cmd.argv[1]);
     int out_bytes_sent = 0;
     if (cli.owlModem->socket.sendTCP(socket, data, &out_bytes_sent))
@@ -864,8 +864,8 @@ class ReceiveUDP : public OwlModemCLIExecutor {
   }
 
   void executor(OwlModemCLI &cli, OwlModemCLICommand &cmd) {
-    uint8_t socket         = (uint8_t)str_to_uint32_t(cmd.argv[0], 10);
-    int len                = 0;
+    uint8_t socket = (uint8_t)str_to_uint32_t(cmd.argv[0], 10);
+    int len        = 0;
     if (cmd.argc >= 2) len = str_to_long_int(cmd.argv[1], 10);
     char buf_ip[64];
     if (cmd.argv[3].len > 512) {
@@ -892,8 +892,8 @@ class ReceiveTCP : public OwlModemCLIExecutor {
   }
 
   void executor(OwlModemCLI &cli, OwlModemCLICommand &cmd) {
-    uint8_t socket         = (uint8_t)str_to_uint32_t(cmd.argv[0], 10);
-    int len                = 0;
+    uint8_t socket = (uint8_t)str_to_uint32_t(cmd.argv[0], 10);
+    int len        = 0;
     if (cmd.argc >= 2) len = str_to_long_int(cmd.argv[1], 10);
     char buf_ip[64];
     if (cmd.argv[3].len > 512) {
@@ -919,11 +919,11 @@ class ReceiveFromUDP : public OwlModemCLIExecutor {
   }
 
   void executor(OwlModemCLI &cli, OwlModemCLICommand &cmd) {
-    uint8_t socket         = (uint8_t)str_to_uint32_t(cmd.argv[0], 10);
-    int len                = 0;
+    uint8_t socket = (uint8_t)str_to_uint32_t(cmd.argv[0], 10);
+    int len        = 0;
     if (cmd.argc >= 2) len = str_to_long_int(cmd.argv[1], 10);
     char buf_ip[64];
-    str remote_ip = {.s = buf_ip, .len = 0};
+    str remote_ip        = {.s = buf_ip, .len = 0};
     uint16_t remote_port = 0;
     if (cmd.argv[3].len > 512) {
       LOGF(L_CLI, "ERROR data input too long %d > max 512 bytes\r\n", cmd.argv[3].len);
@@ -1206,11 +1206,11 @@ class DTLSClientCreate : public OwlModemCLIExecutor {
   }
 
   void executor(OwlModemCLI &cli, OwlModemCLICommand &cmd) {
-    str remote_ip                 = cmd.argv[0];
-    uint16_t remote_port          = str_to_uint32_t(cmd.argv[1], 10);
-    uint16_t local_port           = 0;
+    str remote_ip        = cmd.argv[0];
+    uint16_t remote_port = str_to_uint32_t(cmd.argv[1], 10);
+    uint16_t local_port  = 0;
     if (cmd.argc >= 3) local_port = str_to_uint32_t(cmd.argv[2], 10);
-    str psk_id                    = {0};
+    str psk_id = {0};
     if (cmd.argc >= 4) {
       psk_id = cmd.argv[3];
     } else {
@@ -1490,18 +1490,18 @@ class CoAPPeerSend : public OwlModemCLIExecutor {
       LOG(L_CLI, "ERROR - no CoAP context created - do first coap.create\r\n");
       return;
     }
-    coap_type_e type                  = (coap_type_e)str_to_uint32_t(cmd.argv[0], 10);
-    coap_code_class_e code_class      = (coap_code_class_e)str_to_uint32_t(cmd.argv[1], 10);
-    coap_code_detail_e code_detail    = (coap_code_detail_e)str_to_uint32_t(cmd.argv[2], 10);
-    str uri_path                      = {0};
-    if (cmd.argc >= 4) uri_path       = cmd.argv[3];
-    str uri_query                     = {0};
-    if (cmd.argc >= 5) uri_query      = cmd.argv[4];
-    uint64_t content_format           = 7777;
+    coap_type_e type               = (coap_type_e)str_to_uint32_t(cmd.argv[0], 10);
+    coap_code_class_e code_class   = (coap_code_class_e)str_to_uint32_t(cmd.argv[1], 10);
+    coap_code_detail_e code_detail = (coap_code_detail_e)str_to_uint32_t(cmd.argv[2], 10);
+    str uri_path                   = {0};
+    if (cmd.argc >= 4) uri_path = cmd.argv[3];
+    str uri_query = {0};
+    if (cmd.argc >= 5) uri_query = cmd.argv[4];
+    uint64_t content_format = 7777;
     if (cmd.argc >= 6) content_format = str_to_uint32_t(cmd.argv[5], 10);
-    str payload                       = {0};
-    if (cmd.argc >= 7) payload        = cmd.argv[6];
-    CoAPMessage *msg                  = owl_new CoAPMessage(type, code_class, code_detail, coapPeer->getNextMessageId());
+    str payload = {0};
+    if (cmd.argc >= 7) payload = cmd.argv[6];
+    CoAPMessage *msg = owl_new CoAPMessage(type, code_class, code_detail, coapPeer->getNextMessageId());
     if (!msg) GOTOERR(error);
     if (uri_path.len) {
       str uri_path_token = {0};
@@ -1624,10 +1624,10 @@ class BreakoutSendCommand : public OwlModemCLIExecutor {
       return;
     }
     char buffer[140];
-    str command = {.s = buffer, .len = 0};
+    str command    = {.s = buffer, .len = 0};
     bool is_binary = false;
     if (str_equalcase_prefix_char(cmd.args, "0x")) {
-      str input = {.s = cmd.args.s + 2, .len = cmd.args.len - 2};
+      str input   = {.s = cmd.args.s + 2, .len = cmd.args.len - 2};
       command.len = hex_to_str(command.s, 140, input);
       if (command.len * 2 != input.len) {
         LOG(L_CLI, "ERROR bad input hex string or more than 140 bytes\r\n");
@@ -1707,10 +1707,10 @@ class BreakoutSendCommandWithReceiptRequest : public OwlModemCLIExecutor {
       return;
     }
     char buffer[140];
-    str command = {.s = buffer, .len = 0};
+    str command    = {.s = buffer, .len = 0};
     bool is_binary = false;
     if (str_equalcase_prefix_char(cmd.args, "0x")) {
-      str input = {.s = cmd.args.s + 2, .len = cmd.args.len - 2};
+      str input   = {.s = cmd.args.s + 2, .len = cmd.args.len - 2};
       command.len = hex_to_str(command.s, 140, input);
       if (command.len * 2 != input.len) {
         LOG(L_CLI, "ERROR bad input hex string or more than 140 bytes\r\n");
@@ -2043,7 +2043,7 @@ static str s_help = {.s = "help", .len = 4};
 static str s_quit = {.s = "quit", .len = 4};
 
 static bool in_command_execution = false; /**< Protection for commands which call handleUserInput() inside them */
-static str s_history = {.s = "history", .len = 7};
+static str s_history             = {.s = "history", .len = 7};
 
 int OwlModemCLI::handleUserInput(int resume) {
   if (in_command_execution) return resume;

--- a/src/BreakoutSDK/CLI/OwlModemCLI.cpp
+++ b/src/BreakoutSDK/CLI/OwlModemCLI.cpp
@@ -2122,7 +2122,7 @@ int OwlModemCLI::handleUserInput(int resume) {
             /* AT<something> */
             command.s[command.len >= MODEM_CLI_CMD_LEN ? MODEM_CLI_CMD_LEN - 1 : command.len] = 0;
             at_result_code_e result_code =
-                owlModem->AT.doCommandBlocking(command.s, 2 * 60 * 1000, &response, MODEM_RESPONSE_BUFFER_SIZE);
+                owlModem->AT.doCommandBlocking(command.s, 30 * 1000, &response, MODEM_RESPONSE_BUFFER_SIZE);
             if (!response.len)
               LOGF(L_CLI, " Command [%.*s] returned with result code %s (%d)\r\n", command.len, command.s,
                    at_result_code_text(result_code), result_code);

--- a/src/BreakoutSDK/CLI/OwlModemCLI.cpp
+++ b/src/BreakoutSDK/CLI/OwlModemCLI.cpp
@@ -80,7 +80,7 @@ class SetDebugLevel : public OwlModemCLIExecutor {
 
   void executor(OwlModemCLI &cli, OwlModemCLICommand &cmd) {
     int level = str_to_long_int(cmd.argv[0], 10);
-    cli.owlModem->setDebugLevel(level);
+    owl_log_set_level(level);
     LOGF(L_CLI, "OK level=%d\r\n", level);
   }
 };
@@ -2118,7 +2118,7 @@ int OwlModemCLI::handleUserInput(int resume) {
             /* AT<something> */
             command.s[command.len >= MODEM_CLI_CMD_LEN ? MODEM_CLI_CMD_LEN - 1 : command.len] = 0;
             at_result_code_e result_code =
-                owlModem->doCommand(command.s, 2 * 60 * 1000, &response, MODEM_RESPONSE_BUFFER_SIZE);
+                owlModem->AT.doCommandBlocking(command.s, 2 * 60 * 1000, &response, MODEM_RESPONSE_BUFFER_SIZE);
             if (!response.len)
               LOGF(L_CLI, " Command [%.*s] returned with result code %s (%d)\r\n", command.len, command.s,
                    at_result_code_text(result_code), result_code);

--- a/src/BreakoutSDK/CLI/OwlModemCLI.cpp
+++ b/src/BreakoutSDK/CLI/OwlModemCLI.cpp
@@ -2051,6 +2051,10 @@ int OwlModemCLI::handleUserInput(int resume) {
   if (!owlModem || !debugPort) return 0;
   char c;
   if (!resume) {
+    // flush debug port on startup
+    while (debugPort->available()) {
+      c = debugPort->read();
+    }
     LOGF(L_CLI, "\r\n");
     LOGF(L_CLI, "Welcome to the OwlModem simple CLI interface!\r\n");
     LOGF(L_CLI, "  Type your commands to test the OwlModem API. Hit <TAB> for completion and fast help.\r\n");

--- a/src/BreakoutSDK/CLI/OwlModemCLI.h
+++ b/src/BreakoutSDK/CLI/OwlModemCLI.h
@@ -135,7 +135,7 @@ class OwlModemCLI {
 
   char empty_spaces[MODEM_CLI_CMD_LEN + 1];
   char buf[MODEM_CLI_CMD_LEN + 1];
-  str command = {.s = buf, .len = 0};
+  str command            = {.s = buf, .len = 0};
   OwlModemCLICommand cmd = OwlModemCLICommand();
 };
 

--- a/src/BreakoutSDK/CoAP/CoAPMessage.cpp
+++ b/src/BreakoutSDK/CoAP/CoAPMessage.cpp
@@ -400,7 +400,7 @@ CoAPOption *CoAPMessage::getNextOption(coap_option_number_e number, coap_option_
                                        CoAPOption **iterator) {
   CoAPOption *x = iterator ? (*iterator)->next : this->options;
   while (x && x->number != number && x->format != format)
-    x                     = x->next;
+    x = x->next;
   if (iterator) *iterator = x;
   return x;
 }

--- a/src/BreakoutSDK/CoAP/CoAPOption.cpp
+++ b/src/BreakoutSDK/CoAP/CoAPOption.cpp
@@ -64,7 +64,7 @@ void CoAPOption::log(log_level_t level) {
       switch (this->number) {
         case CoAP_Option__Content_Format:
           LOGF(level, " - CoAPOption %d (%s): %llu - %s\r\n", this->number, coap_option_number_text(this->number),
-               this->value.uint, coap_content_format_text((coap_content_format_e) this->value.uint));
+               this->value.uint, coap_content_format_text((coap_content_format_e)this->value.uint));
           break;
         default:
           LOGF(level, " - CoAPOption %d (%s): %llu\r\n", this->number, coap_option_number_text(this->number),

--- a/src/BreakoutSDK/CoAP/CoAPPeer.cpp
+++ b/src/BreakoutSDK/CoAP/CoAPPeer.cpp
@@ -324,7 +324,7 @@ void CoAPPeer::setHandlers(CoAPPeer_MessageHandler_f handler_message, CoAPPeer_D
 
 int CoAPPeer::sendUnreliably(CoAPMessage *message, int probing_rate, int max_transmit_span) {
   uint8_t buf[MODEM_UDP_BUFFER_SIZE];
-  bin_t b = {.s = buf, .idx = 0, .max = MODEM_UDP_BUFFER_SIZE};
+  bin_t b       = {.s = buf, .idx = 0, .max = MODEM_UDP_BUFFER_SIZE};
   int is_ackrst = 0;
   if (!message) {
     LOG(L_ERR, "Null parameter\r\n");
@@ -383,7 +383,7 @@ error:
 int CoAPPeer::sendReliably(CoAPMessage *message, CoAPPeer_ClientTransactionCallback_f cb, void *cb_param,
                            int max_retransmit, int max_transmit_span) {
   uint8_t buf[MODEM_UDP_BUFFER_SIZE];
-  bin_t b = {.s = buf, .idx = 0, .max = MODEM_UDP_BUFFER_SIZE};
+  bin_t b                      = {.s = buf, .idx = 0, .max = MODEM_UDP_BUFFER_SIZE};
   coap_client_transaction_t *t = 0;
   if (!message) {
     LOG(L_ERR, "Null parameter\r\n");

--- a/src/BreakoutSDK/CoAP/enums.h
+++ b/src/BreakoutSDK/CoAP/enums.h
@@ -247,9 +247,8 @@ typedef enum {
                                                    (TEMPORARY - registered 2018-08-09, expires 2019-08-09)*/
   CoAP_Content_Format__application_csrattrs =
       285, /**< [RFC7030][draft-ietf-ace-coap-est] (TEMPORARY - registered 2018-08-09, expires 2019-08-09)*/
-  CoAP_Content_Format__application_pkcs10 =
-      286, /**< [RFC-ietf-lamps-rfc5751-bis-12][RFC5967][draft-ietf-ace-coap-est] (TEMPORARY - registered 2018-08-09,
-              expires 2019-08-09)*/
+  CoAP_Content_Format__application_pkcs10 = 286, /**< [RFC-ietf-lamps-rfc5751-bis-12][RFC5967][draft-ietf-ace-coap-est]
+                                                    (TEMPORARY - registered 2018-08-09, expires 2019-08-09)*/
   CoAP_Content_Format__application_senml_xml          = 310,   /**< [RFC8428]*/
   CoAP_Content_Format__application_sensml_xml         = 311,   /**< [RFC8428]*/
   CoAP_Content_Format__application_vnd_ocf_cbor       = 10000, /**< [Michael_Koster]*/

--- a/src/BreakoutSDK/DTLS/OwlDTLSClient.cpp
+++ b/src/BreakoutSDK/DTLS/OwlDTLSClient.cpp
@@ -63,7 +63,7 @@ static int sendToPeer(struct dtls_context_t *ctx, session_t *session, uint8 *buf
   OwlDTLSClient *owlDTLS = (OwlDTLSClient *)dtls_get_app_data(ctx);
 
   str data = {.s = (char *)buf, .len = len};
-  int cnt = owlDTLS->sendRawData(data);
+  int cnt  = owlDTLS->sendRawData(data);
   if (cnt != len) {
     LOG(L_ERR, "Error on sending data\r\n");
     return 0;
@@ -284,7 +284,7 @@ int OwlDTLSClient::connect(uint16_t local_port, str remote_ip, uint16_t remote_p
   if (str_find_char(remote_ip, ":") < 0) {
     /* IPv4 */
     this->dtls_dst.size = IP_Address__IPv4;
-    for (int i                    = 0; i < 4 && str_tok(remote_ip, ".", &token); i++)
+    for (int i = 0; i < 4 && str_tok(remote_ip, ".", &token); i++)
       this->dtls_dst.addr.ipv4[i] = str_to_uint32_t(token, 10);
   } else {
     /* IPv6 */

--- a/src/BreakoutSDK/DTLS/OwlDTLSClient.h
+++ b/src/BreakoutSDK/DTLS/OwlDTLSClient.h
@@ -126,7 +126,7 @@ class OwlDTLSClient {
   OwlModem *owlModem = 0;
   uint8_t socket_id  = 255;
   char c_remote_ip[64];
-  str remote_ip = {.s = c_remote_ip, .len = 0};
+  str remote_ip        = {.s = c_remote_ip, .len = 0};
   uint16_t remote_port = 0;
 
   clock_time_t next_retransmit_timer = 0;

--- a/src/BreakoutSDK/modem/ArduinoSeeedOwlSerial.h
+++ b/src/BreakoutSDK/modem/ArduinoSeeedOwlSerial.h
@@ -4,11 +4,21 @@
 
 class ArduinoSeeedUSBOwlSerial : public IOwlSerial {
  public:
-  ArduinoSeeedUSBOwlSerial(USBSerial* serial) : serial_(serial) {if (serial_ != nullptr) serial_->enableBlockingTx();}
-  virtual ~ArduinoSeeedUSBOwlSerial() {if (serial_) serial_->end();}
-  int32_t read(uint8_t *buf, uint32_t count) override {return (serial_ != nullptr) ? serial_->readBytes(buf, count) : -1;}
-  int32_t available() override {return (serial_ != nullptr) ? serial_->available() : -1;}
-  int32_t write(const uint8_t *buf, uint32_t count) override { return (serial_ != nullptr) ? serial_->write(buf, count) : -1;}
+  ArduinoSeeedUSBOwlSerial(USBSerial *serial) : serial_(serial) {
+    if (serial_ != nullptr) serial_->enableBlockingTx();
+  }
+  virtual ~ArduinoSeeedUSBOwlSerial() {
+    if (serial_) serial_->end();
+  }
+  int32_t read(uint8_t *buf, uint32_t count) override {
+    return (serial_ != nullptr) ? serial_->readBytes(buf, count) : -1;
+  }
+  int32_t available() override {
+    return (serial_ != nullptr) ? serial_->available() : -1;
+  }
+  int32_t write(const uint8_t *buf, uint32_t count) override {
+    return (serial_ != nullptr) ? serial_->write(buf, count) : -1;
+  }
 
  private:
   USBSerial *serial_{nullptr};
@@ -16,11 +26,20 @@ class ArduinoSeeedUSBOwlSerial : public IOwlSerial {
 
 class ArduinoSeeedHwOwlSerial : public IOwlSerial {
  public:
-  ArduinoSeeedHwOwlSerial(HardwareSerial* serial) : serial_(serial) {}
-  virtual ~ArduinoSeeedHwOwlSerial() {if (serial_) serial_->end();}
-  int32_t read(uint8_t *buf, uint32_t count) override {return (serial_ != nullptr) ? serial_->readBytes(buf, count) : -1;}
-  int32_t available() override {return (serial_ != nullptr) ? serial_->available() : -1;}
-  int32_t write(const uint8_t *buf, uint32_t count) override { return (serial_ != nullptr) ? serial_->write(buf, count) : -1;}
+  ArduinoSeeedHwOwlSerial(HardwareSerial *serial) : serial_(serial) {
+  }
+  virtual ~ArduinoSeeedHwOwlSerial() {
+    if (serial_) serial_->end();
+  }
+  int32_t read(uint8_t *buf, uint32_t count) override {
+    return (serial_ != nullptr) ? serial_->readBytes(buf, count) : -1;
+  }
+  int32_t available() override {
+    return (serial_ != nullptr) ? serial_->available() : -1;
+  }
+  int32_t write(const uint8_t *buf, uint32_t count) override {
+    return (serial_ != nullptr) ? serial_->write(buf, count) : -1;
+  }
 
  private:
   HardwareSerial *serial_{nullptr};

--- a/src/BreakoutSDK/modem/ArduinoSeeedOwlSerial.h
+++ b/src/BreakoutSDK/modem/ArduinoSeeedOwlSerial.h
@@ -1,0 +1,27 @@
+#include "IOwlSerial.h"
+#include <usb_serial.h>
+#include <HardwareSerial.h>
+
+class ArduinoSeeedUSBOwlSerial : public IOwlSerial {
+ public:
+  ArduinoSeeedUSBOwlSerial(USBSerial* serial) : serial_(serial) {if (serial_ != nullptr) serial_->enableBlockingTx();}
+  virtual ~ArduinoSeeedUSBOwlSerial() {if (serial_) serial_->end();}
+  int32_t read(uint8_t *buf, uint32_t count) override {return (serial_ != nullptr) ? serial_->readBytes(buf, count) : -1;}
+  int32_t available() override {return (serial_ != nullptr) ? serial_->available() : -1;}
+  int32_t write(const uint8_t *buf, uint32_t count) override { return (serial_ != nullptr) ? serial_->write(buf, count) : -1;}
+
+ private:
+  USBSerial *serial_{nullptr};
+};
+
+class ArduinoSeeedHwOwlSerial : public IOwlSerial {
+ public:
+  ArduinoSeeedHwOwlSerial(HardwareSerial* serial) : serial_(serial) {}
+  virtual ~ArduinoSeeedHwOwlSerial() {if (serial_) serial_->end();}
+  int32_t read(uint8_t *buf, uint32_t count) override {return (serial_ != nullptr) ? serial_->readBytes(buf, count) : -1;}
+  int32_t available() override {return (serial_ != nullptr) ? serial_->available() : -1;}
+  int32_t write(const uint8_t *buf, uint32_t count) override { return (serial_ != nullptr) ? serial_->write(buf, count) : -1;}
+
+ private:
+  HardwareSerial *serial_{nullptr};
+};

--- a/src/BreakoutSDK/modem/IOwlSerial.h
+++ b/src/BreakoutSDK/modem/IOwlSerial.h
@@ -5,7 +5,8 @@
 
 class IOwlSerial {
  public:
-  virtual ~IOwlSerial() {}
+  virtual ~IOwlSerial() {
+  }
 
   /**
    * Number of bytes available on the interface
@@ -29,4 +30,4 @@ class IOwlSerial {
    */
   virtual int32_t write(const uint8_t *buf, uint32_t count) = 0;
 };
-#endif // __I_OWL_SERIAL_H__
+#endif  // __I_OWL_SERIAL_H__

--- a/src/BreakoutSDK/modem/IOwlSerial.h
+++ b/src/BreakoutSDK/modem/IOwlSerial.h
@@ -1,0 +1,32 @@
+#ifndef __I_OWL_SERIAL_H__
+#define __I_OWL_SERIAL_H__
+
+#include <cstdint>
+
+class IOwlSerial {
+ public:
+  virtual ~IOwlSerial() {}
+
+  /**
+   * Number of bytes available on the interface
+   * @return - number of bytes available or a negative value for an error
+   */
+  virtual int32_t available() = 0;
+
+  /**
+   * Non-blocking read from the device
+   * @param buf - buffer to store the read data
+   * @param count - maximum number of bytes to read
+   * @return - number of bytes read. Can be zero if no data is available or negative in case of an error
+   */
+  virtual int32_t read(uint8_t *buf, uint32_t count) = 0;
+
+  /**
+   * Non-blocking write to the device
+   * @param buf - buffer containing the written data
+   * @param count - number of data to write
+   * @return - number of bytes actually written. Can be negative in case of an error
+   */
+  virtual int32_t write(const uint8_t *buf, uint32_t count) = 0;
+};
+#endif // __I_OWL_SERIAL_H__

--- a/src/BreakoutSDK/modem/OwlModem.cpp
+++ b/src/BreakoutSDK/modem/OwlModem.cpp
@@ -31,7 +31,15 @@
 
 
 OwlModem::OwlModem(HardwareSerial *modem_port_in, USBSerial *debug_port_in, HardwareSerial *gnss_port_in)
-    : modem_port(modem_port_in), debug_port(debug_port_in), gnss_port(gnss_port_in), AT(&modem_port), information(&AT), SIM(&AT), network(&AT), pdn(&AT), socket(&AT) {
+    : modem_port(modem_port_in),
+      debug_port(debug_port_in),
+      gnss_port(gnss_port_in),
+      AT(&modem_port),
+      information(&AT),
+      SIM(&AT),
+      network(&AT),
+      pdn(&AT),
+      socket(&AT) {
   modem_port_in->begin(SerialModule_Baudrate);
   if (!modem_port_in) {
     LOG(L_ERR, "OwlModem initialized without modem port. That is not going to work\r\n");
@@ -50,7 +58,7 @@ OwlModem::OwlModem(HardwareSerial *modem_port_in, USBSerial *debug_port_in, Hard
 
   has_modem_port = (modem_port_in != nullptr);
   has_debug_port = (debug_port_in != nullptr);
-  has_gnss_port = (gnss_port_in != nullptr);
+  has_gnss_port  = (gnss_port_in != nullptr);
 }
 
 OwlModem::~OwlModem() {
@@ -70,7 +78,6 @@ int OwlModem::powerOn(owl_power_m bit_mask) {
   int errCnt     = 0;
 
   if ((bit_mask & Owl_PowerOnOff__Modem) != 0) {
-
     if (isPoweredOn()) return 1;
 
     // Set RTS pin down to enable UART communication
@@ -192,7 +199,8 @@ int OwlModem::initModem(int testing_variant) {
     }
 
     if ((testing_variant & Testing__Set_APN_Bands_to_Berlin) != 0) {
-      if (AT.doCommandBlocking("AT+URAT=8", 5000, 0, 0) != AT_Result_Code__OK) LOG(L_WARN, "Error setting RAT to NB1\r\n");
+      if (AT.doCommandBlocking("AT+URAT=8", 5000, 0, 0) != AT_Result_Code__OK)
+        LOG(L_WARN, "Error setting RAT to NB1\r\n");
       // This is a bitmask, LSB meaning Band1, MSB meaning Band64
       if (AT.doCommandBlocking("AT+UBANDMASK=0,0", 5000, 0, 0) != AT_Result_Code__OK)
         LOG(L_WARN, "Error setting band mask for Cat-M1 to none\r\n");
@@ -205,7 +213,8 @@ int OwlModem::initModem(int testing_variant) {
         LOG(L_WARN, "Error setting custom APN\r\n");
     }
     if ((testing_variant & Testing__Set_APN_Bands_to_US) != 0) {
-      if (AT.doCommandBlocking("AT+URAT=8", 5000, 0, 0) != AT_Result_Code__OK) LOG(L_WARN, "Error setting RAT to NB1\r\n");
+      if (AT.doCommandBlocking("AT+URAT=8", 5000, 0, 0) != AT_Result_Code__OK)
+        LOG(L_WARN, "Error setting RAT to NB1\r\n");
       // This is a bitmask, LSB meaning Band1, MSB meaning Band64
       if (AT.doCommandBlocking("AT+UBANDMASK=0,0", 5000, 0, 0) != AT_Result_Code__OK)
         LOG(L_WARN, "Error setting band mask for Cat-M1 to 2/4/5/12\r\n");
@@ -300,8 +309,8 @@ int OwlModem::waitForNetworkRegistration(char *purpose, int testing_variant) {
   if ((testing_variant & Testing__Skip_Set_Host_Device_Information) != 0) return 1;
 
   if (!setHostDeviceInformation(purpose)) {
-      LOG(L_WARN, "Error setting HostDeviceInformation.  If this persists, please inform Twilio support.\r\n");
-      // TODO: set a flag to report to Twilio Object-16 registration timed out or failed
+    LOG(L_WARN, "Error setting HostDeviceInformation.  If this persists, please inform Twilio support.\r\n");
+    // TODO: set a flag to report to Twilio Object-16 registration timed out or failed
   }
 
   return 1;
@@ -334,7 +343,7 @@ void OwlModem::bypassCLI() {
       else
         index = 0;
       if (index == s_exitbypass.len) {
-        modem_port.write((uint8_t*)"\r\n", 2);
+        modem_port.write((uint8_t *)"\r\n", 2);
         in_bypass = 0;
         AT.resume();
         return;
@@ -344,7 +353,7 @@ void OwlModem::bypassCLI() {
 }
 
 void OwlModem::bypassGNSSCLI() {
-  if (!has_gnss_port || ! has_debug_port) {
+  if (!has_gnss_port || !has_debug_port) {
     return;
   }
   // TODO - set echo on/off - maybe with parameter to this function? but that will mess with other code
@@ -363,7 +372,7 @@ void OwlModem::bypassGNSSCLI() {
       else
         index = 0;
       if (index == s_exitbypass.len) {
-        gnss_port.write((uint8_t*)"\r\n", 2);
+        gnss_port.write((uint8_t *)"\r\n", 2);
         return;
       }
     }
@@ -382,21 +391,21 @@ void OwlModem::bypass() {
   }
   while (debug_port.available())
     debug_port.read(&c, 1);
-    modem_port.write(&c, 1);
+  modem_port.write(&c, 1);
 }
 
 void OwlModem::bypassGNSS() {
-  if (!has_gnss_port || ! has_debug_port) {
+  if (!has_gnss_port || !has_debug_port) {
     return;
   }
 
   uint8_t c;
   while (gnss_port.available())
     gnss_port.read(&c, 1);
-    debug_port.write(&c, 1);
+  debug_port.write(&c, 1);
   while (debug_port.available())
     debug_port.read(&c, 1);
-    gnss_port.write(&c, 1);
+  gnss_port.write(&c, 1);
 }
 
 static str s_dev_kit = STRDECL("devkit");
@@ -505,7 +514,7 @@ int OwlModem::drainGNSSRx(str *gnss_buffer, int gnss_buffer_len) {
       memmove(gnss_buffer->s, gnss_buffer->s + shift, gnss_buffer->len);
       full = 1;
     }
-    received = gnss_port.read((uint8_t*)gnss_buffer->s + gnss_buffer->len, available);
+    received = gnss_port.read((uint8_t *)gnss_buffer->s + gnss_buffer->len, available);
     //    LOG(L_WARN, "Rx %d bytes\r\n", received);
     if (received != available) {
       LOG(L_ERR, "gnss_port said %d bytes available, but received %d.\r\n", available, received);
@@ -532,5 +541,3 @@ error:
 /*void OwlModem::setDebugLevel(int level) {
   owl_log_set_level(level);
 }*/
-
-

--- a/src/BreakoutSDK/modem/OwlModem.cpp
+++ b/src/BreakoutSDK/modem/OwlModem.cpp
@@ -30,12 +30,27 @@
 
 
 
-OwlModem::OwlModem(HardwareSerial *modem_port, USBSerial *debug_port, HardwareSerial *gnss_port)
-    : modem_port(modem_port), debug_port(debug_port), gnss_port(gnss_port) {
-  if (debug_port) debug_port->enableBlockingTx();  // reliably write to it
+OwlModem::OwlModem(HardwareSerial *modem_port_in, USBSerial *debug_port_in, HardwareSerial *gnss_port_in)
+    : modem_port(modem_port_in), debug_port(debug_port_in), gnss_port(gnss_port_in), AT(&modem_port), information(&AT), SIM(&AT), network(&AT), pdn(&AT), socket(&AT) {
+  modem_port_in->begin(SerialModule_Baudrate);
+  if (!modem_port_in) {
+    LOG(L_ERR, "OwlModem initialized without modem port. That is not going to work\r\n");
+  }
+
+  if (gnss_port_in) {
+    gnss_port_in->begin(SerialGNSS_BAUDRATE);
+  }
+
+  if (debug_port_in) {
+    debug_port_in->enableBlockingTx();
+  }
   // Seed the random
   pinMode(ANALOG_RND_PIN, INPUT);
   randomSeed(analogRead(ANALOG_RND_PIN));
+
+  has_modem_port = (modem_port_in != nullptr);
+  has_debug_port = (debug_port_in != nullptr);
+  has_gnss_port = (gnss_port_in != nullptr);
 }
 
 OwlModem::~OwlModem() {
@@ -43,7 +58,9 @@ OwlModem::~OwlModem() {
 
 
 int OwlModem::powerOn(owl_power_m bit_mask) {
-  if (!modem_port) return 0;
+  if (!has_modem_port) {
+    return false;
+  }
 
   /*
    * This code is mostly taken from the Seeed ublox_sara_r4.cpp, then simplified. For a different board, this has to be
@@ -53,7 +70,6 @@ int OwlModem::powerOn(owl_power_m bit_mask) {
   int errCnt     = 0;
 
   if ((bit_mask & Owl_PowerOnOff__Modem) != 0) {
-    modem_port->begin(SerialModule_Baudrate);
 
     if (isPoweredOn()) return 1;
 
@@ -92,7 +108,6 @@ int OwlModem::powerOn(owl_power_m bit_mask) {
   }
 
   if ((bit_mask & Owl_PowerOnOff__GNSS) != 0) {
-    if (gnss_port) gnss_port->begin(SerialGNSS_BAUDRATE);
     pinMode(GNSS_PWR_PIN, OUTPUT);
     digitalWrite(GNSS_PWR_PIN, HIGH);
   }
@@ -124,7 +139,7 @@ int OwlModem::powerOff(owl_power_m bit_mask) {
 }
 
 int OwlModem::isPoweredOn() {
-  return doCommand("AT", 1000, 0, 0) == AT_Result_Code__OK;
+  return AT.doCommandBlocking("AT", 1000, 0, 0) == AT_Result_Code__OK;
 }
 
 
@@ -150,34 +165,10 @@ int OwlModem::initModem(int testing_variant) {
                                                    AT_UMNOPROF__MNO_PROFILE__TMO :
                                                    AT_UMNOPROF__MNO_PROFILE__SW_Default;
 
-
-  if (doCommand("ATV1", 1000, 0, 0) != AT_Result_Code__OK) {
-    LOG(L_WARN, "Potential error setting commands to always return response codes [%.*s]\r\n", response.len,
-        response.s);
-  }
-
-  if (doCommand("ATQ0", 1000, 0, 0) != AT_Result_Code__OK) {
-    LOG(L_WARN, "Potential error setting commands to return text response codes\r\n");
+  if (!AT.initTerminal()) {
     goto error;
   }
 
-  if (doCommand("ATE0", 1000, 0, 0) != AT_Result_Code__OK) {
-    LOG(L_WARN, "Error setting echo off\r\n");
-    goto error;
-  }
-
-  if (doCommand("AT+CMEE=2", 1000, 0, 0) != AT_Result_Code__OK) {
-    LOG(L_WARN, "Potential error setting Modem Errors output to verbose (not numeric) values\r\n");
-    goto error;
-  }
-
-  if (doCommand("ATS3=13", 1000, 0, 0) != AT_Result_Code__OK) {
-    LOG(L_WARN, "Error setting command terminating character\r\n");
-  }
-
-  if (doCommand("ATS4=10", 1000, 0, 0) != AT_Result_Code__OK) {
-    LOG(L_WARN, "Error setting response separator character\r\n");
-  }
 
   /* Resetting the modem network parameters */
   if (!network.getModemMNOProfile(&current_profile)) {
@@ -201,26 +192,26 @@ int OwlModem::initModem(int testing_variant) {
     }
 
     if ((testing_variant & Testing__Set_APN_Bands_to_Berlin) != 0) {
-      if (doCommand("AT+URAT=8", 5000, 0, 0) != AT_Result_Code__OK) LOG(L_WARN, "Error setting RAT to NB1\r\n");
+      if (AT.doCommandBlocking("AT+URAT=8", 5000, 0, 0) != AT_Result_Code__OK) LOG(L_WARN, "Error setting RAT to NB1\r\n");
       // This is a bitmask, LSB meaning Band1, MSB meaning Band64
-      if (doCommand("AT+UBANDMASK=0,0", 5000, 0, 0) != AT_Result_Code__OK)
+      if (AT.doCommandBlocking("AT+UBANDMASK=0,0", 5000, 0, 0) != AT_Result_Code__OK)
         LOG(L_WARN, "Error setting band mask for Cat-M1 to none\r\n");
-      if (doCommand("AT+UBANDMASK=1,168761503", 5000, 0, 0) != AT_Result_Code__OK)
+      if (AT.doCommandBlocking("AT+UBANDMASK=1,168761503", 5000, 0, 0) != AT_Result_Code__OK)
         LOG(L_WARN, "Error setting band mask for NB1 to 168761503 (manual default\r\n");
       //
-      //      if (doCommand("AT+UBANDMASK=1,524416", 5000, 0, 0) != AT_Result_Code__OK)
+      //      if (AT.doCommandBlocking("AT+UBANDMASK=1,524416", 5000, 0, 0) != AT_Result_Code__OK)
       //        LOG(L_WARN, "Error setting band mask for NB1 to Band8 (900MHz) and Band20 (800MHz)\r\n");
-      if (doCommand("AT+CGDCONT=1,\"IP\",\"" TESTING_APN "\"", 5000, 0, 0) != AT_Result_Code__OK)
+      if (AT.doCommandBlocking("AT+CGDCONT=1,\"IP\",\"" TESTING_APN "\"", 5000, 0, 0) != AT_Result_Code__OK)
         LOG(L_WARN, "Error setting custom APN\r\n");
     }
     if ((testing_variant & Testing__Set_APN_Bands_to_US) != 0) {
-      if (doCommand("AT+URAT=8", 5000, 0, 0) != AT_Result_Code__OK) LOG(L_WARN, "Error setting RAT to NB1\r\n");
+      if (AT.doCommandBlocking("AT+URAT=8", 5000, 0, 0) != AT_Result_Code__OK) LOG(L_WARN, "Error setting RAT to NB1\r\n");
       // This is a bitmask, LSB meaning Band1, MSB meaning Band64
-      if (doCommand("AT+UBANDMASK=0,0", 5000, 0, 0) != AT_Result_Code__OK)
+      if (AT.doCommandBlocking("AT+UBANDMASK=0,0", 5000, 0, 0) != AT_Result_Code__OK)
         LOG(L_WARN, "Error setting band mask for Cat-M1 to 2/4/5/12\r\n");
-      if (doCommand("AT+UBANDMASK=1,2074", 5000, 0, 0) != AT_Result_Code__OK)
+      if (AT.doCommandBlocking("AT+UBANDMASK=1,2074", 5000, 0, 0) != AT_Result_Code__OK)
         LOG(L_WARN, "Error setting band mask for NB1 to 2/4/5/12 (manual default)\r\n");
-      // if (doCommand("AT+CGDCONT=1,\"IP\",\"" TESTING_APN "\"", 5000, 0, 0) != AT_Result_Code__OK)
+      // if (AT.doCommandBlocking("AT+CGDCONT=1,\"IP\",\"" TESTING_APN "\"", 5000, 0, 0) != AT_Result_Code__OK)
       // LOG(L_WARN, "Error setting custom APN\r\n");
     }
 
@@ -232,60 +223,35 @@ int OwlModem::initModem(int testing_variant) {
       delay(100);
     }
 
-    /* Redo the basic initialization */
-    if (doCommand("ATV1", 1000, 0, 0) != AT_Result_Code__OK) {
-      LOG(L_WARN, "Potential error setting commands to always return response codes [%.*s]\r\n", response.len,
-          response.s);
-    }
-
-    if (doCommand("ATQ0", 1000, 0, 0) != AT_Result_Code__OK) {
-      LOG(L_WARN, "Potential error setting commands to return text response codes\r\n");
+    if (!AT.initTerminal()) {
       goto error;
-    }
-
-    if (doCommand("ATE0", 1000, 0, 0) != AT_Result_Code__OK) {
-      LOG(L_WARN, "Error setting echo off\r\n");
-      goto error;
-    }
-
-    if (doCommand("AT+CMEE=2", 1000, 0, 0) != AT_Result_Code__OK) {
-      LOG(L_WARN, "Potential error setting Modem Errors output to verbose (not numeric) values\r\n");
-      goto error;
-    }
-
-    if (doCommand("ATS3=13", 1000, 0, 0) != AT_Result_Code__OK) {
-      LOG(L_WARN, "Error setting command terminating character\r\n");
-    }
-
-    if (doCommand("ATS4=10", 1000, 0, 0) != AT_Result_Code__OK) {
-      LOG(L_WARN, "Error setting response separator character\r\n");
     }
   }
 
 
-  if (doCommand("AT+CSCS=\"GSM\"", 1000, 0, 0) != AT_Result_Code__OK) {
+  if (AT.doCommandBlocking("AT+CSCS=\"GSM\"", 1000, 0, 0) != AT_Result_Code__OK) {
     LOG(L_WARN, "Potential error setting character set to GSM\r\n");
   }
 
   /* Set the on-board LEDs */
-  if (doCommand("AT+UGPIOC=23,10", 5000, 0, 0) != AT_Result_Code__OK) {
+  if (AT.doCommandBlocking("AT+UGPIOC=23,10", 5000, 0, 0) != AT_Result_Code__OK) {
     LOG(L_WARN, "..  - failed to map pin 23 (yellow led)  to \"module operating status indication\"\r\n");
   }
-  if (doCommand("AT+UGPIOC=16,2", 5000, 0, 0) != AT_Result_Code__OK) {
+  if (AT.doCommandBlocking("AT+UGPIOC=16,2", 5000, 0, 0) != AT_Result_Code__OK) {
     LOG(L_WARN, "..  - failed to map pin 16 (blue led) to \"network status indication\"\r\n");
   }
 
   /* TODO - decide if to keep this in */
-  if (doCommand("AT+CREG=2", 1000, 0, 0) != AT_Result_Code__OK) {
+  if (AT.doCommandBlocking("AT+CREG=2", 1000, 0, 0) != AT_Result_Code__OK) {
     LOG(L_WARN,
         "Potential error setting URC to Registration and Location Updates for Network Registration Status events\r\n");
   }
-  if (doCommand("AT+CGREG=2", 1000, 0, 0) != AT_Result_Code__OK) {
+  if (AT.doCommandBlocking("AT+CGREG=2", 1000, 0, 0) != AT_Result_Code__OK) {
     LOG(L_WARN,
         "Potential error setting GPRS URC to Registration and Location Updates for Network Registration Status "
         "events\r\n");
   }
-  if (doCommand("AT+CEREG=2", 1000, 0, 0) != AT_Result_Code__OK) {
+  if (AT.doCommandBlocking("AT+CEREG=2", 1000, 0, 0) != AT_Result_Code__OK) {
     LOG(L_WARN,
         "Potential error setting EPS URC to Registration and Location Updates for Network Registration Status "
         "events\r\n");
@@ -293,22 +259,18 @@ int OwlModem::initModem(int testing_variant) {
 
   if (SIM.handler_cpin) saved_handler = SIM.handler_cpin;
   SIM.setHandlerPIN(initCheckPIN);
-  if (doCommand("AT+CPIN?", 5000, &response, MODEM_RESPONSE_BUFFER_SIZE) != AT_Result_Code__OK) {
+  if (AT.doCommandBlocking("AT+CPIN?", 5000, &response, MODEM_RESPONSE_BUFFER_SIZE) != AT_Result_Code__OK) {
     LOG(L_WARN, "Error checking PIN status\r\n");
   }
   SIM.setHandlerPIN(saved_handler);
 
-  if (doCommand("AT+UDCONF=1,1", 1000, 0, 0) != AT_Result_Code__OK) {
+  if (AT.doCommandBlocking("AT+UDCONF=1,1", 1000, 0, 0) != AT_Result_Code__OK) {
     LOG(L_WARN, "Potential error setting ublox HEX mode for socket ops send/receive\r\n");
   }
 
+  /* TODO: probably deprecated*/
   if (!information.getModel(&response, MODEM_RESPONSE_BUFFER_SIZE)) {
     LOG(L_WARN, "Potential error caching the modem model\r\n");
-  } else {
-    if (str_equal_char(response, "SARA-N410-02B")) {
-      LOG(L_NOTICE, "Detected the SARA-N410-02B - marking for the listen bug workaround\r\n");
-      model = Owl_Modem__SARA_N410_02B__Listen_Bug;
-    }
   }
 
   LOG(L_DBG, "Modem correctly initialized\r\n");
@@ -350,23 +312,31 @@ int OwlModem::waitForNetworkRegistration(char *purpose, int testing_variant) {
 static str s_exitbypass = {.s = "exitbypass", .len = 10};
 
 void OwlModem::bypassCLI() {
-  if (!modem_port || !debug_port) return;
+  if (!has_modem_port || !has_debug_port) {
+    return;
+  }
+
   // TODO - set echo on/off - maybe with parameter to this function? but that will mess with other code
   in_bypass = 1;
-  char c;
+  uint8_t c;
   int index = 0;
+  AT.pause();
   while (1) {
-    if (modem_port->available()) debug_port->write(modem_port->read());
-    if (debug_port->available()) {
-      c = debug_port->read();
-      modem_port->write(c);
+    if (modem_port.available()) {
+      modem_port.read(&c, 1);
+      debug_port.write(&c, 1);
+    }
+    if (debug_port.available()) {
+      debug_port.read(&c, 1);
+      modem_port.write(&c, 1);
       if (s_exitbypass.s[index] == c)
         index++;
       else
         index = 0;
       if (index == s_exitbypass.len) {
-        modem_port->write("\r\n", 2);
+        modem_port.write((uint8_t*)"\r\n", 2);
         in_bypass = 0;
+        AT.resume();
         return;
       }
     }
@@ -374,21 +344,26 @@ void OwlModem::bypassCLI() {
 }
 
 void OwlModem::bypassGNSSCLI() {
-  if (!gnss_port || !debug_port) return;
+  if (!has_gnss_port || ! has_debug_port) {
+    return;
+  }
   // TODO - set echo on/off - maybe with parameter to this function? but that will mess with other code
-  char c;
+  uint8_t c;
   int index = 0;
   while (1) {
-    if (gnss_port->available()) debug_port->write(gnss_port->read());
-    if (debug_port->available()) {
-      c = debug_port->read();
-      gnss_port->write(c);
+    if (gnss_port.available()) {
+      gnss_port.read(&c, 1);
+      debug_port.write(&c, 1);
+    }
+    if (debug_port.available()) {
+      debug_port.read(&c, 1);
+      gnss_port.write(&c, 1);
       if (s_exitbypass.s[index] == c)
         index++;
       else
         index = 0;
       if (index == s_exitbypass.len) {
-        gnss_port->write("\r\n", 2);
+        gnss_port.write((uint8_t*)"\r\n", 2);
         return;
       }
     }
@@ -396,17 +371,32 @@ void OwlModem::bypassGNSSCLI() {
 }
 
 void OwlModem::bypass() {
-  while (modem_port->available())
-    debug_port->write(modem_port->read());
-  while (debug_port->available())
-    modem_port->write(debug_port->read());
+  if (!has_modem_port || !has_debug_port) {
+    return;
+  }
+
+  uint8_t c;
+  while (modem_port.available()) {
+    modem_port.read(&c, 1);
+    debug_port.write(&c, 1);
+  }
+  while (debug_port.available())
+    debug_port.read(&c, 1);
+    modem_port.write(&c, 1);
 }
 
 void OwlModem::bypassGNSS() {
-  while (gnss_port->available())
-    debug_port->write(gnss_port->read());
-  while (debug_port->available())
-    gnss_port->write(debug_port->read());
+  if (!has_gnss_port || ! has_debug_port) {
+    return;
+  }
+
+  uint8_t c;
+  while (gnss_port.available())
+    gnss_port.read(&c, 1);
+    debug_port.write(&c, 1);
+  while (debug_port.available())
+    debug_port.read(&c, 1);
+    gnss_port.write(&c, 1);
 }
 
 static str s_dev_kit = STRDECL("devkit");
@@ -469,7 +459,7 @@ int OwlModem::setHostDeviceInformation(str purpose) {
   LOG(L_INFO, "Setting HostDeviceInformation to: %.*s\r\n", hostdevice_information.len, hostdevice_information.s);
 
   for (int attempts = 10; attempts > 0; attempts--) {
-    if (doCommand(command_buffer, 1000, &response, MODEM_RESPONSE_BUFFER_SIZE) == AT_Result_Code__OK) {
+    if (AT.doCommandBlocking(command_buffer, 1000, &response, MODEM_RESPONSE_BUFFER_SIZE) == AT_Result_Code__OK) {
       LOG(L_INFO, ".. setting HostDeviceInformation successful.\r\n");
       registered = true;
       break;
@@ -498,225 +488,14 @@ str OwlModem::getShortHostDeviceInformation() {
 }
 
 
-
-int OwlModem::sendData(str data) {
-  if (!modem_port) return 0;
-  int written = 0, cnt;
-  do {
-    cnt = modem_port->write(data.s, data.len);
-    if (cnt <= 0) {
-      LOG(L_ERR, "Had %d bytes to send on modem_port, but wrote only %d.\r\n", data.len, written);
-      return 0;
-    }
-    written += cnt;
-  } while (written < data.len);
-  // LOG(L_INFO, "Tx\r\n");
-  // LOGSTR(L_INFO, data);
-  return 1;
-}
-
-int OwlModem::sendData(char *data) {
-  str s = {.s = data, .len = strlen(data)};
-  return sendData(s);
-}
-
-
-/**
- * These prefixes indicate lines which are not errors if not processed as URC, because they belong
- * to regular commands.
- */
-str prefix_non_urc[] = {
-
-    /* OwlModemInformation */
-    STRDECL("+CBC"),
-    STRDECL("+CIND"),
-
-    /* OwlModemSIM */
-    STRDECL("+CCID"),
-    STRDECL("+CNUM"),
-
-    /* OwlModemNetwork */
-    STRDECL("+CFUN"),
-    STRDECL("+UMNOPROF"),
-    STRDECL("+COPS"),
-    STRDECL("+CSQ"),
-
-    /* OwlModemPDN */
-    STRDECL("+CGPADDR: "),
-
-    /* OwlModemSocket */
-    STRDECL("+USOCR"),
-    STRDECL("+USOER"),
-    STRDECL("+USOWR"),
-    STRDECL("+USOST"),
-    STRDECL("+USORD"),
-    STRDECL("+USORF"),
-    STRDECL("+USOCO"),
-
-    /* End of list marker */
-    {0}};
-
-int OwlModem::processURC(str line, int report_unknown) {
-  if (line.len < 1 || line.s[0] != '+') return 0;
-  int k = str_find_char(line, ": ");
-  if (k < 0) return 0;
-  str urc = {.s = line.s, .len = k};
-  str data = {.s = line.s + k + 2, .len = line.len - k - 2};
-
-  LOG(L_DBG, "URC [%.*s] Data [%.*s]\r\n", urc.len, urc.s, data.len, data.s);
-
-  /* ordered based on expected incoming count of events */
-  if (this->network.processURC(urc, data)) return 1;
-  if (this->socket.processURC(urc, data)) return 1;
-  if (this->SIM.processURC(urc, data)) return 1;
-
-  if (report_unknown) {
-    for (int i = 0; prefix_non_urc[i].s; i++)
-      if (str_equal(urc, prefix_non_urc[i])) return 0;
-    // If it wasn't on the ignored list, report it
-    LOG(L_WARN, "Not handled URC [%.*s] with data [%.*s]\r\n", urc.len, urc.s, data.len, data.s);
-  }
-  return 0;
-}
-
-int OwlModem::getNextCompleteLine(int start_idx, str *line) {
-  if (!line) return 0;
-  line->s   = 0;
-  line->len = 0;
-  int i;
-  int start = start_idx;
-
-  for (i = start_idx; i < rx_buffer.len;) {
-    if (rx_buffer.s[i] != '\r' && rx_buffer.s[i] != '\n') {
-      /* part of current line */
-      i++;
-      continue;
-    }
-    if (start == i) {
-      /* skip over empty lines */
-      i++;
-      start = i;
-      continue;
-    }
-    line->s   = rx_buffer.s + start;
-    line->len = i - start;
-    return 1;
-  }
-
-  return 0;
-}
-
-void OwlModem::removeRxBufferLine(str line) {
-  /* Remove the line + next CRLF */
-  if (line.s + line.len + 2 <= rx_buffer.s + rx_buffer.len && line.s[line.len] == '\r' && line.s[line.len + 1] == '\n')
-    line.len += 2;
-  int before_len = line.s - rx_buffer.s;
-  int after_len  = rx_buffer.len - before_len - line.len;
-  if (after_len > 0) {
-    memmove(line.s, line.s + line.len, after_len);
-    rx_buffer.len -= line.len;
-  } else if (after_len == 0) {
-    rx_buffer.len -= line.len;
-  } else {
-    LOG(L_ERR, "Bad len calculation %d\r\n", after_len);
-  }
-}
-
-void OwlModem::consumeUnsolicited() {
-  str line                = {0};
-  int start               = 0;
-  int saved_rx_buffer_len = rx_buffer.len;
-
-  LOG(L_DBG, "Old-Buffer\r\n");
-  LOGSTR(L_DBG, this->rx_buffer);
-
-  while (getNextCompleteLine(start, &line)) {
-    processURC(line, 1);
-    start = line.s - rx_buffer.s;
-    removeRxBufferLine(line);
-  }
-
-  /* remove leading \r\n - aka empty lines */
-  int cnt = 0;
-  for (cnt = 0; cnt < rx_buffer.len; cnt++)
-    if (rx_buffer.s[cnt] != '\r' && rx_buffer.s[cnt] != '\n') break;
-  if (cnt > 0) {
-    memmove(rx_buffer.s, rx_buffer.s + cnt, rx_buffer.len - cnt);
-    rx_buffer.len -= cnt;
-  }
-
-  if (saved_rx_buffer_len != rx_buffer.len) {
-    LOG(L_DBG, "New-Buffer\r\n");
-    LOGSTR(L_DBG, this->rx_buffer);
-  }
-}
-
-void OwlModem::consumeUnsolicitedInCommandResponse() {
-  str line                = {0};
-  int start               = 0;
-  int saved_rx_buffer_len = rx_buffer.len;
-  int consumed            = 0;
-
-  LOG(L_DBG, "Old-Buffer\r\n");
-  LOGSTR(L_DBG, this->rx_buffer);
-
-  while (getNextCompleteLine(start, &line)) {
-    LOG(L_DBG, "Line [%.*s]\r\n", line.len, line.s);
-
-    consumed = processURC(line, 0);
-    if (consumed) {
-      start = line.s - rx_buffer.s;
-      removeRxBufferLine(line);
-    } else {
-      start = line.s - rx_buffer.s + line.len;
-    }
-  }
-
-  if (saved_rx_buffer_len != rx_buffer.len) {
-    LOG(L_DBG, "New-Buffer\r\n");
-    LOGSTR(L_DBG, this->rx_buffer);
-  }
-}
-
-
-int OwlModem::drainModemRxToBuffer() {
-  LOG(L_MEM, "Trying to drain modem\r\n");
-  int available, received, total = 0;
-  while ((available = modem_port->available()) > 0) {
-    if (available > MODEM_Rx_BUFFER_SIZE) available = MODEM_Rx_BUFFER_SIZE;
-    if (available > MODEM_Rx_BUFFER_SIZE - rx_buffer.len) {
-      int shift = available - (MODEM_Rx_BUFFER_SIZE - rx_buffer.len);
-      LOG(L_WARN, "Rx buffer full with %d bytes. Dropping oldest %d bytes.\r\n", rx_buffer.len, shift);
-      rx_buffer.len -= shift;
-      memmove(rx_buffer.s, rx_buffer.s + shift, rx_buffer.len);
-    }
-    received = modem_port->readBytes(rx_buffer.s + rx_buffer.len, available);
-    if (received != available) {
-      LOG(L_ERR, "modem_port said %d bytes available, but received %d.\r\n", available, received);
-      if (received < 0) goto error;
-    }
-
-    rx_buffer.len += received;
-    total += received;
-
-    if (rx_buffer.len > MODEM_Rx_BUFFER_SIZE) {
-      LOG(L_ERR, "Bug in the rx_buffer_len calculation %d > %d\r\n", rx_buffer.len, MODEM_Rx_BUFFER_SIZE);
-      goto error;
-    }
-
-    LOG(L_DBG, "Modem Rx - size changed from %d to %d bytes\r\n", rx_buffer.len - received, rx_buffer.len);
-    LOGSTR(L_DBG, this->rx_buffer);
-  }
-error:
-  LOG(L_MEM, "Done draining modem %d\r\n", total);
-  return total;
-}
-
 int OwlModem::drainGNSSRx(str *gnss_buffer, int gnss_buffer_len) {
-  if (!gnss_buffer || !gnss_port) return 0;
+  if (gnss_buffer == nullptr || !has_gnss_port) {
+    return 0;
+  }
+
   LOG(L_MEM, "Trying to drain GNSS data\r\n");
   int available, received, total = 0, full = 0;
-  while ((available = gnss_port->available()) > 0) {
+  while ((available = gnss_port.available()) > 0) {
     if (available > gnss_buffer_len) available = gnss_buffer_len;
     //    LOG(L_DBG, "Available %d bytes\r\n", available);
     if (available > gnss_buffer_len - gnss_buffer->len) {
@@ -726,7 +505,7 @@ int OwlModem::drainGNSSRx(str *gnss_buffer, int gnss_buffer_len) {
       memmove(gnss_buffer->s, gnss_buffer->s + shift, gnss_buffer->len);
       full = 1;
     }
-    received = gnss_port->readBytes(gnss_buffer->s + gnss_buffer->len, available);
+    received = gnss_port.read((uint8_t*)gnss_buffer->s + gnss_buffer->len, available);
     //    LOG(L_WARN, "Rx %d bytes\r\n", received);
     if (received != available) {
       LOG(L_ERR, "gnss_port said %d bytes available, but received %d.\r\n", available, received);
@@ -750,179 +529,8 @@ error:
   return total;
 }
 
-int OwlModem::handleRxOnTimer() {
-  LOG(L_MEM, "Entering timer on interrupt\r\n");
-  int received = 0;
-
-  if (!modem_port) goto error;
-
-  if (in_timer) goto error;
-
-  in_timer = 1;  // no goto error after this, we need to reset this flag
-
-  /* Don't enter here in case a command is in progress. URC shouldn't come during a command and will call this later */
-  if (in_command || in_bypass) goto done;
-
-  received = drainModemRxToBuffer();
-  if (rx_buffer.len > 0) consumeUnsolicited();
-
-done:
-  in_timer = 0;
-  LOG(L_MEM, "Done timer on interrupt\r\n");
-  return 1;
-error:
-  LOG(L_MEM, "Done timer on interrupt\r\n");
-  return 0;
-}
-
-
-at_result_code_e OwlModem::extractResult(str *out_response, int max_response_len) {
-  at_result_code_e result_code;
-  for (int i = 0; i <= rx_buffer.len - 6; i++) {
-    if (rx_buffer.s[i] != '\r' && rx_buffer.s[i] != '\n') continue;
-    result_code = at_result_code_extract(rx_buffer.s + i, rx_buffer.len - i);
-    if (result_code == AT_Result_Code__cme_error) {
-      //      LOG(L_INFO, "Rx-Before [%.*s]\r\n", rx_buffer.len, rx_buffer.s);
-      /* CME Error received - extract the text into response and return ERROR */
-      result_code = AT_Result_Code__ERROR;
-      char *start = rx_buffer.s + i + 2 /* CRLF */ + 12 /* length of "+CME ERROR: " */;
-      int len     = 0;
-      while (start + len + 1 < rx_buffer.s + rx_buffer.len) {
-        if (start[len] == '\r' && start[len + 1] == '\n') break;
-        len++;
-      }
-      if (out_response) {
-        memcpy(out_response->s, start, len > max_response_len ? max_response_len : len);
-        out_response->len = len;
-      }
-      /* truncate the rx_buffer */
-      int next_index = i + 2 /* CRLF */ + 12 /* length of "+CME ERROR: " */ + len + 2 /* CRLF */;
-      rx_buffer.len -= next_index;
-      if (rx_buffer.len > 0) memmove(rx_buffer.s, rx_buffer.s + next_index, rx_buffer.len);
-      //      LOG(L_INFO, "Result %d - %s\r\n", result_code, at_result_code_text(result_code));
-      //      LOG(L_INFO, "Rx-After  [%.*s]\r\n", rx_buffer.len, rx_buffer.s);
-      return result_code;
-    } else if (result_code >= AT_Result_Code__OK) {
-      /* extract the response before the result code */
-      if (out_response) {
-        /* remove the CR LF prefix/suffix */
-        char *start = rx_buffer.s;
-        int len     = i;
-        while (len > 0 && (start[0] == '\r' || start[0] == '\n')) {
-          start++;
-          len--;
-        }
-        while (len > 0 && (start[len - 1] == '\r' || start[len - 1] == '\n')) {
-          len--;
-        }
-        out_response->len = len > max_response_len ? max_response_len : len;
-        memcpy(out_response->s, start, out_response->len);
-        if (out_response->len < max_response_len) out_response->s[out_response->len] = '\0';
-      }
-      /* truncate the rx_buffer */
-      int next_index = i + 2 /* CRLF */ + strlen(at_result_code_text(result_code)) + 2 /* CRLF */;
-      rx_buffer.len -= next_index;
-      if (rx_buffer.len > 0) memmove(rx_buffer.s, rx_buffer.s + next_index, rx_buffer.len);
-      //      LOG(L_INFO, "Result %d - %s\r\n", result_code,  at_result_code_text(result_code);
-      return result_code;
-    }
-  }
-  return AT_Result_Code__unknown;
-}
-
-at_result_code_e OwlModem::doCommand(str command, uint32_t timeout_millis, str *out_response, int max_response_len) {
-  if (out_response) out_response->len = 0;
-  at_result_code_e result_code;
-  owl_time_t timeout;
-  int received;
-  if (!modem_port) goto failure;
-
-  /* Make sure that the timer has finished handling Rx and prevent it from re-entering */
-  in_command = 1;
-  /* wait for the timer to exit */
-  int i;
-  for (i = 0; i < 100 && in_timer != 0; i++)
-    delay(50);
-  if (i >= 100) {
-    LOG(L_ERR, "[%.*s] either called from a timer, or timeout waiting for timer to exit\r\n", command.len, command.s);
-    return AT_Result_Code__failure;
-  }
-
-  /* Tx */
-  if (!sendData(command)) goto failure;
-  //  LOG(L_DBG, "[%.*s] sent\r\n", command.len, command.s);
-
-  /* Before sending the actual command, get rid of the URC in the pipe. This way, the result of this command will be
-   * nice and empty. */
-  if (rx_buffer.len) consumeUnsolicited();
-
-  /* Tx CRLF*/
-  if (!sendData(CMDLT)) goto failure;
-  LOG(L_DBG, "[%.*s] sent\r\n", command.len, command.s);
-  //  LOG(L_DBG, "[CRLF] sent\r\n");
-
-  /* Rx */
-  timeout = owl_time() + timeout_millis;
-  do {
-    received = drainModemRxToBuffer();
-    if (!received) {
-      delay(50);
-      if (owl_time() < timeout)
-        continue;
-      else
-        break;
-    }
-    consumeUnsolicitedInCommandResponse();
-    result_code = extractResult(out_response, max_response_len);
-    if (result_code >= AT_Result_Code__OK) {
-      in_command = 0;
-      if (out_response)
-        LOG(L_DBG, " - Execution complete - Result %d - %s Data [%.*s]\r\n", result_code,
-            at_result_code_text(result_code), out_response->len, out_response->s);
-      else
-        LOG(L_DBG, " - Execution complete - Result %d - %s\r\n", result_code, at_result_code_text(result_code));
-      return result_code;
-    }
-  } while (owl_time() < timeout);
-
-  if (!str_equalcase_char(command, "AT")) LOG(L_WARN, " - Timed-out on [%.*s]\r\n", command.len, command.s);
-
-  //  // reset the buffer on timeout
-  //  rx_buffer.len = 0;
-  // or don't reset on timeout - the handleRxOnTimer() shall drop orphan lines
-
-  in_command = 0;
-  return AT_Result_Code__timeout;
-failure:
-  LOG(L_WARN, " - Failure on [%.*s]\r\n", command.len, command.s);
-  in_command = 0;
-  return AT_Result_Code__failure;
-}
-
-at_result_code_e OwlModem::doCommand(char *command, uint32_t timeout_millis, str *out_response, int max_response_len) {
-  str s = {.s = command, .len = strlen(command)};
-  return doCommand(s, timeout_millis, out_response, max_response_len);
-}
-
-void OwlModem::setDebugLevel(int level) {
+/*void OwlModem::setDebugLevel(int level) {
   owl_log_set_level(level);
-}
+}*/
 
-void OwlModem::filterResponse(str prefix, str *response) {
-  if (!response) return;
-  str line = {0};
-  while (str_tok(*response, "\r\n", &line)) {
-    if (!str_equal_prefix(line, prefix)) {
-      /* Remove the line + next CRLF */
-      if (line.s + line.len + 2 <= response->s + response->len && line.s[line.len] == '\r' &&
-          line.s[line.len + 1] == '\n')
-        line.len += 2;
-      str_shrink_inside(*response, line.s, line.len);
-      line.len = 0;
-      continue;
-    }
-    /* Remove the prefix */
-    str_shrink_inside(*response, line.s, prefix.len);
-    line.len -= prefix.len;
-  }
-}
+

--- a/src/BreakoutSDK/modem/OwlModem.h
+++ b/src/BreakoutSDK/modem/OwlModem.h
@@ -149,6 +149,7 @@ class OwlModem {
   ArduinoSeeedHwOwlSerial modem_port;
   ArduinoSeeedUSBOwlSerial debug_port;
   ArduinoSeeedHwOwlSerial gnss_port;
+
  public:
   /*
    * Main APIs
@@ -211,7 +212,7 @@ class OwlModem {
    */
   void computeHostDeviceInformation(str purpose);
 
-public: // These things are not part of the API. TODO - make them private
+ public:  // These things are not part of the API. TODO - make them private
   int drainGNSSRx(str *gnss_buffer, int gnss_buffer_len);
 };
 

--- a/src/BreakoutSDK/modem/OwlModemAT.cpp
+++ b/src/BreakoutSDK/modem/OwlModemAT.cpp
@@ -1,0 +1,518 @@
+#include "OwlModemAT.h"
+#include <stdio.h>
+
+bool OwlModemAT::initTerminal() {
+  if (doCommandBlocking("ATV1", 1000, 0, 0) != AT_Result_Code__OK) {
+    LOG(L_WARN, "Potential error setting commands to always return response codes\r\n");
+  }
+
+  if (doCommandBlocking("ATQ0", 1000, 0, 0) != AT_Result_Code__OK) {
+    LOG(L_ERR, "Error setting commands to return text response codes\r\n");
+    return false;
+  }
+
+  if (doCommandBlocking("ATE0", 1000, 0, 0) != AT_Result_Code__OK) {
+    LOG(L_ERR, "Error setting echo off\r\n");
+    return false;
+  }
+
+  if (doCommandBlocking("AT+CMEE=2", 1000, 0, 0) != AT_Result_Code__OK) {
+    LOG(L_ERR, "Error setting Modem Errors output to verbose (not numeric) values\r\n");
+    return false;
+  }
+
+  if (doCommandBlocking("ATS3=13", 1000, 0, 0) != AT_Result_Code__OK) {
+    LOG(L_WARN, "Error setting command terminating character\r\n");
+  }
+
+  if (doCommandBlocking("ATS4=10", 1000, 0, 0) != AT_Result_Code__OK) {
+    LOG(L_WARN, "Error setting response separator character\r\n");
+  }
+
+  return true;
+
+}
+
+bool OwlModemAT::registerUrcHandler(UrcHandler handler, void* priv) {
+  if (num_urc_handlers_ >= MaxUrcHandlers) {
+    return false;
+  }
+
+  urc_handlers_[num_urc_handlers_] = handler;
+  urc_handler_params_[num_urc_handlers_] = priv;
+
+  ++num_urc_handlers_;
+  return true;
+}
+
+int OwlModemAT::sendData(str data) {
+  ssize_t written = 0;
+  ssize_t cnt;
+  do {
+    cnt = serial_->write((const uint8_t*)data.s+written, data.len-written);
+    if (cnt <= 0) {
+      LOG(L_ERR, "Had %d bytes to send on modem_port, but wrote only %d.\r\n", data.len, written);
+      return 0;
+    }
+    written += cnt;
+  } while (written < data.len);
+  return 1;
+}
+
+int OwlModemAT::sendData(char *data) {
+  str s = {.s = data, .len = strlen(data)};
+  return sendData(s);
+}
+
+/*TODO: rewrite as a ring buffer*/
+at_result_code_e OwlModemAT::extractResult(str *out_response, int max_response_len) {
+  at_result_code_e result_code;
+  for (int i = 0; i <= rx_buffer.len - 6; i++) {
+    if (rx_buffer.s[i] != '\r' && rx_buffer.s[i] != '\n') continue;
+    result_code = at_result_code_extract(rx_buffer.s + i, rx_buffer.len - i);
+    if (result_code == AT_Result_Code__cme_error) {
+      //      LOG(L_INFO, "Rx-Before [%.*s]\r\n", rx_buffer.len, rx_buffer.s);
+      /* CME Error received - extract the text into response and return ERROR */
+      result_code = AT_Result_Code__ERROR;
+      char *start = rx_buffer.s + i + 2 /* CRLF */ + 12 /* length of "+CME ERROR: " */;
+      int len     = 0;
+      while (start + len + 1 < rx_buffer.s + rx_buffer.len) {
+        if (start[len] == '\r' && start[len + 1] == '\n') break;
+        len++;
+      }
+      if (out_response) {
+        memcpy(out_response->s, start, len > max_response_len ? max_response_len : len);
+        out_response->len = len;
+      }
+      /* truncate the rx_buffer */
+      int next_index = i + 2 /* CRLF */ + 12 /* length of "+CME ERROR: " */ + len + 2 /* CRLF */;
+      rx_buffer.len -= next_index;
+      if (rx_buffer.len > 0) memmove(rx_buffer.s, rx_buffer.s + next_index, rx_buffer.len);
+      //      LOG(L_INFO, "Result %d - %s\r\n", result_code, at_result_code_text(result_code));
+      //      LOG(L_INFO, "Rx-After  [%.*s]\r\n", rx_buffer.len, rx_buffer.s);
+      return result_code;
+    } else if (result_code >= AT_Result_Code__OK) {
+      /* extract the response before the result code */
+      if (out_response) {
+        /* remove the CR LF prefix/suffix */
+        char *start = rx_buffer.s;
+        int len     = i;
+        while (len > 0 && (start[0] == '\r' || start[0] == '\n')) {
+          start++;
+          len--;
+        }
+        while (len > 0 && (start[len - 1] == '\r' || start[len - 1] == '\n')) {
+          len--;
+        }
+        out_response->len = len > max_response_len ? max_response_len : len;
+        memcpy(out_response->s, start, out_response->len);
+        if (out_response->len < max_response_len) out_response->s[out_response->len] = '\0';
+      }
+      /* truncate the rx_buffer */
+      int next_index = i + 2 /* CRLF */ + strlen(at_result_code_text(result_code)) + 2 /* CRLF */;
+      rx_buffer.len -= next_index;
+      if (rx_buffer.len > 0) memmove(rx_buffer.s, rx_buffer.s + next_index, rx_buffer.len);
+      //      LOG(L_INFO, "Result %d - %s\r\n", result_code,  at_result_code_text(result_code);
+      return result_code;
+    }
+  }
+  return AT_Result_Code__unknown;
+}
+
+at_result_code_e OwlModemAT::sendCommand(str command) {
+  if (serial_ == nullptr) {
+    LOG(L_ERR, "sendCommand [%.*s] failed: serial device unavailable\r\n", command.len, command.s);
+    return AT_Result_Code__failure;
+  }
+
+  if (paused_) {
+    LOG(L_ERR, "sendCommand [%.*s] failed: modem is paused\r\n", command.len, command.s);
+    return AT_Result_Code__failure;
+  }
+
+  if (in_command_) {
+    LOG(L_ERR, "sendCommand [%.*s] failed: attempt to send while waiting for a response from the previous one\r\n", command.len, command.s);
+    return AT_Result_Code__failure;
+  }
+
+  /* Tx */
+  if (!sendData(command)) {
+    LOG(L_ERR, "sendCommand [%.*s] failed: writing to serial device failed\r\n", command.len, command.s);
+    return AT_Result_Code__failure;
+  }
+
+  /* Tx CRLF*/
+  if (!sendData(CMDLT)) {
+    LOG(L_ERR, "sendCommand [%.*s] failed: writing to serial device failed\r\n", command.len, command.s);
+    return AT_Result_Code__failure;
+  }
+
+  in_command_ = true;
+  return AT_Result_Code__OK;
+}
+
+/*at_result_code_e OwlModemAT::doCommand(str command, uint32_t timeout_millis, str *out_response, int max_response_len) {
+  if (out_response) out_response->len = 0;
+  at_result_code_e result_code;
+  owl_time_t timeout;
+  int received;
+
+  in_command_ = 1;
+  int i;
+  int in_timer = 0;
+  for (i = 0; i < 100 && in_timer != 0; i++)
+    owl_delay(50);
+  if (i >= 100) {
+    LOG(L_ERR, "[%.*s] either called from a timer, or timeout waiting for timer to exit\r\n", command.len, command.s);
+    return AT_Result_Code__failure;
+  }
+
+  if (!sendData(command)) goto failure;
+  //  LOG(L_DBG, "[%.*s] sent\r\n", command.len, command.s);
+
+  if (rx_buffer.len) consumeUnsolicited();
+
+  if (!sendData(CMDLT)) goto failure;
+  LOG(L_DBG, "[%.*s] sent\r\n", command.len, command.s);
+  timeout = owl_time() + timeout_millis;
+  do {
+    received = drainModemRxToBuffer();
+    if (!received) {
+      owl_delay(50);
+      if (owl_time() < timeout)
+        continue;
+      else
+        break;
+    }
+    consumeUnsolicitedInCommandResponse();
+    result_code = extractResult(out_response, max_response_len);
+    if (result_code >= AT_Result_Code__OK) {
+      in_command_ = 0;
+      if (out_response)
+        LOG(L_DBG, " - Execution complete - Result %d - %s Data [%.*s]\r\n", result_code,
+            at_result_code_text(result_code), out_response->len, out_response->s);
+      else
+        LOG(L_DBG, " - Execution complete - Result %d - %s\r\n", result_code, at_result_code_text(result_code));
+      return result_code;
+    }
+  } while (owl_time() < timeout);
+
+  if (!str_equalcase_char(command, "AT")) LOG(L_WARN, " - Timed-out on [%.*s]\r\n", command.len, command.s);
+
+  //  // reset the buffer on timeout
+  //  rx_buffer.len = 0;
+  // or don't reset on timeout - the handleRxOnTimer() shall drop orphan lines
+
+  in_command_ = 0;
+  return AT_Result_Code__timeout;
+failure:
+  LOG(L_WARN, " - Failure on [%.*s]\r\n", command.len, command.s);
+  in_command_ = 0;
+  return AT_Result_Code__failure;
+}
+
+at_result_code_e OwlModemAT::doCommand(char *command, uint32_t timeout_millis, str *out_response, int max_response_len) {
+  str s = {.s = command, .len = strlen(command)};
+  return doCommand(s, timeout_millis, out_response, max_response_len);
+}*/
+
+at_result_code_e OwlModemAT::getLastCommandResponse(str *out_response, int max_response_len) {
+  if (out_response) {
+    out_response->len = 0;
+  }
+
+  consumeUnsolicitedInCommandResponse();
+  at_result_code_e result_code = extractResult(out_response, max_response_len);
+  if (result_code >= AT_Result_Code__OK) {
+    in_command_ = false;
+    if (out_response)
+      LOG(L_DBG, " - Execution complete - Result %d - %s Data [%.*s]\r\n", result_code,
+          at_result_code_text(result_code), out_response->len, out_response->s);
+    else
+      LOG(L_DBG, " - Execution complete - Result %d - %s\r\n", result_code, at_result_code_text(result_code));
+    return result_code;
+  } else {
+    return AT_Result_Code__in_progress;
+  }
+}
+
+at_result_code_e OwlModemAT::doCommandBlocking(str command, uint32_t timeout_millis, str *out_response, int max_response_len) {
+  owl_time_t timeout;
+  int received;
+  at_result_code_e result_code;
+
+  /* Before sending the actual command, get rid of the URC in the pipe. This way, the result of this command will be
+   * nice and empty. */
+  if (rx_buffer.len) {
+    consumeUnsolicited();
+  }
+
+  result_code = sendCommand(command);
+  if (result_code != AT_Result_Code__OK) {
+    LOG(L_WARN, " - Failed to send [%.*s]\r\n", command.len, command.s);
+    return result_code;
+  }
+  LOG(L_DBG, "[%.*s] sent\r\n", command.len, command.s);
+
+  /* Rx */
+  timeout = owl_time() + timeout_millis;
+  do {
+    received = drainModemRxToBuffer();
+    if (!received) {
+      owl_delay(50);
+      if (owl_time() < timeout)
+        continue;
+      else
+        break;
+    }
+    result_code = getLastCommandResponse(out_response, max_response_len);
+    if (result_code >= AT_Result_Code__OK) {
+      return result_code;
+    }
+  } while (owl_time() < timeout);
+
+  if (!str_equalcase_char(command, "AT")) {
+    LOG(L_WARN, " - Timed-out on [%.*s]\r\n", command.len, command.s);
+  }
+
+  interruptLastCommand();
+  return AT_Result_Code__timeout;
+}
+
+at_result_code_e OwlModemAT::doCommandBlocking(char *command, uint32_t timeout_millis, str *out_response, int max_response_len) {
+  str s = {.s = command, .len = strlen(command)};
+  return doCommandBlocking(s, timeout_millis, out_response, max_response_len);
+}
+
+void OwlModemAT::filterResponse(str prefix, str *response) {
+  if (!response) return;
+  str line = {0};
+  while (str_tok(*response, "\r\n", &line)) {
+    if (!str_equal_prefix(line, prefix)) {
+      /* Remove the line + next CRLF */
+      if (line.s + line.len + 2 <= response->s + response->len && line.s[line.len] == '\r' &&
+          line.s[line.len + 1] == '\n')
+        line.len += 2;
+      str_shrink_inside(*response, line.s, line.len);
+      line.len = 0;
+      continue;
+    }
+    /* Remove the prefix */
+    str_shrink_inside(*response, line.s, prefix.len);
+    line.len -= prefix.len;
+  }
+}
+
+/**
+ * These prefixes indicate lines which are not errors if not processed as URC, because they belong
+ * to regular commands.
+ */
+/*static str prefix_non_urc[] = {
+
+    // OwlModemInformation
+    STRDECL("+CBC"),
+    STRDECL("+CIND"),
+
+    // OwlModemSIM
+    STRDECL("+CCID"),
+    STRDECL("+CNUM"),
+
+    // OwlModemNetwork
+    STRDECL("+CFUN"),
+    STRDECL("+UMNOPROF"),
+    STRDECL("+COPS"),
+    STRDECL("+CSQ"),
+
+    // OwlModemPDN
+    STRDECL("+CGPADDR: "),
+
+    // OwlModemSocket
+    STRDECL("+USOCR"),
+    STRDECL("+USOER"),
+    STRDECL("+USOWR"),
+    STRDECL("+USOST"),
+    STRDECL("+USORD"),
+    STRDECL("+USORF"),
+    STRDECL("+USOCO"),
+
+    // End of list marker
+    {0}};*/
+
+int OwlModemAT::processURC(str line, int report_unknown) {
+  if (line.len < 1 || line.s[0] != '+') return 0;
+  int k = str_find_char(line, ": ");
+  if (k < 0) return 0;
+  str urc = {.s = line.s, .len = k};
+  str data = {.s = line.s + k + 2, .len = line.len - k - 2};
+
+  LOG(L_DBG, "URC [%.*s] Data [%.*s]\r\n", urc.len, urc.s, data.len, data.s);
+
+  /* ordered based on expected incoming count of events */
+  for (int i = 0; i < num_urc_handlers_; i++) {
+    if (urc_handlers_[i](urc, data, urc_handler_params_[i])) {
+      return 1;
+    }
+  }
+  /*if (this->network.processURC(urc, data)) return 1;
+  if (this->socket.processURC(urc, data)) return 1;
+  if (this->SIM.processURC(urc, data)) return 1;*/
+
+  if (report_unknown) {
+  //  for (int i = 0; prefix_non_urc[i].s; i++)
+  //    if (str_equal(urc, prefix_non_urc[i])) return 0;
+    // If it wasn't on the ignored list, report it
+    LOG(L_WARN, "Not handled URC [%.*s] with data [%.*s]\r\n", urc.len, urc.s, data.len, data.s);
+  }
+  return 0;
+}
+
+int OwlModemAT::getNextCompleteLine(int start_idx, str *line) {
+  if (!line) return 0;
+  line->s   = 0;
+  line->len = 0;
+  int i;
+  int start = start_idx;
+
+  for (i = start_idx; i < rx_buffer.len;) {
+    if (rx_buffer.s[i] != '\r' && rx_buffer.s[i] != '\n') {
+      /* part of current line */
+      i++;
+      continue;
+    }
+    if (start == i) {
+      /* skip over empty lines */
+      i++;
+      start = i;
+      continue;
+    }
+    line->s   = rx_buffer.s + start;
+    line->len = i - start;
+    return 1;
+  }
+
+  return 0;
+}
+
+void OwlModemAT::removeRxBufferLine(str line) {
+  /* Remove the line + next CRLF */
+  if (line.s + line.len + 2 <= rx_buffer.s + rx_buffer.len && line.s[line.len] == '\r' && line.s[line.len + 1] == '\n')
+    line.len += 2;
+  int before_len = line.s - rx_buffer.s;
+  int after_len  = rx_buffer.len - before_len - line.len;
+  if (after_len > 0) {
+    memmove(line.s, line.s + line.len, after_len);
+    rx_buffer.len -= line.len;
+  } else if (after_len == 0) {
+    rx_buffer.len -= line.len;
+  } else {
+    LOG(L_ERR, "Bad len calculation %d\r\n", after_len);
+  }
+}
+
+void OwlModemAT::consumeUnsolicited() {
+  str line                = {0};
+  int start               = 0;
+  int saved_rx_buffer_len = rx_buffer.len;
+
+  LOG(L_DBG, "Old-Buffer\r\n");
+  LOGSTR(L_DBG, this->rx_buffer);
+
+  while (getNextCompleteLine(start, &line)) {
+    processURC(line, 1);
+    start = line.s - rx_buffer.s;
+    removeRxBufferLine(line);
+  }
+
+  /* remove leading \r\n - aka empty lines */
+  int cnt = 0;
+  for (cnt = 0; cnt < rx_buffer.len; cnt++)
+    if (rx_buffer.s[cnt] != '\r' && rx_buffer.s[cnt] != '\n') break;
+  if (cnt > 0) {
+    memmove(rx_buffer.s, rx_buffer.s + cnt, rx_buffer.len - cnt);
+    rx_buffer.len -= cnt;
+  }
+
+  if (saved_rx_buffer_len != rx_buffer.len) {
+    LOG(L_DBG, "New-Buffer\r\n");
+    LOGSTR(L_DBG, this->rx_buffer);
+  }
+}
+
+void OwlModemAT::consumeUnsolicitedInCommandResponse() {
+  str line                = {0};
+  int start               = 0;
+  int saved_rx_buffer_len = rx_buffer.len;
+  int consumed            = 0;
+
+  LOG(L_DBG, "Old-Buffer\r\n");
+  LOGSTR(L_DBG, this->rx_buffer);
+
+  while (getNextCompleteLine(start, &line)) {
+    LOG(L_DBG, "Line [%.*s]\r\n", line.len, line.s);
+
+    consumed = processURC(line, 0);
+    if (consumed) {
+      start = line.s - rx_buffer.s;
+      removeRxBufferLine(line);
+    } else {
+      start = line.s - rx_buffer.s + line.len;
+    }
+  }
+
+  if (saved_rx_buffer_len != rx_buffer.len) {
+    LOG(L_DBG, "New-Buffer\r\n");
+    LOGSTR(L_DBG, this->rx_buffer);
+  }
+}
+
+
+int OwlModemAT::drainModemRxToBuffer() {
+  LOG(L_MEM, "Trying to drain modem\r\n");
+  int available, received, total = 0;
+  while ((available = serial_->available()) > 0) {
+    if (available > MODEM_Rx_BUFFER_SIZE) available = MODEM_Rx_BUFFER_SIZE;
+    if (available > MODEM_Rx_BUFFER_SIZE - rx_buffer.len) {
+      int shift = available - (MODEM_Rx_BUFFER_SIZE - rx_buffer.len);
+      LOG(L_WARN, "Rx buffer full with %d bytes. Dropping oldest %d bytes.\r\n", rx_buffer.len, shift);
+      rx_buffer.len -= shift;
+      memmove(rx_buffer.s, rx_buffer.s + shift, rx_buffer.len);
+    }
+    received = serial_->read((uint8_t*)rx_buffer.s + rx_buffer.len, available);
+    if (received != available) {
+      LOG(L_ERR, "modem_port said %d bytes available, but received %d.\r\n", available, received);
+      if (received < 0) goto error;
+    }
+
+    rx_buffer.len += received;
+    total += received;
+
+    if (rx_buffer.len > MODEM_Rx_BUFFER_SIZE) {
+      LOG(L_ERR, "Bug in the rx_buffer_len calculation %d > %d\r\n", rx_buffer.len, MODEM_Rx_BUFFER_SIZE);
+      goto error;
+    }
+
+    LOG(L_DBG, "Modem Rx - size changed from %d to %d bytes\r\n", rx_buffer.len - received, rx_buffer.len);
+    LOGSTR(L_DBG, this->rx_buffer);
+  }
+error:
+  LOG(L_MEM, "Done draining modem %d\r\n", total);
+  return total;
+}
+
+// OYTIS: NEVER call anything non-trivial from an interrupt
+void OwlModemAT::spin() {
+  LOG(L_MEM, "Spin on modem\r\n");
+
+  /* Don't enter here in case a command is in progress. URC shouldn't come during a command and will call this later */
+  if (serial_ == nullptr || paused_) {
+    return;
+  }
+
+  drainModemRxToBuffer();
+  if (rx_buffer.len > 0) {
+    consumeUnsolicited();
+  }
+
+  LOG(L_MEM, "Done spinning\r\n");
+}
+

--- a/src/BreakoutSDK/modem/OwlModemAT.cpp
+++ b/src/BreakoutSDK/modem/OwlModemAT.cpp
@@ -30,15 +30,14 @@ bool OwlModemAT::initTerminal() {
   }
 
   return true;
-
 }
 
-bool OwlModemAT::registerUrcHandler(UrcHandler handler, void* priv) {
+bool OwlModemAT::registerUrcHandler(UrcHandler handler, void *priv) {
   if (num_urc_handlers_ >= MaxUrcHandlers) {
     return false;
   }
 
-  urc_handlers_[num_urc_handlers_] = handler;
+  urc_handlers_[num_urc_handlers_]       = handler;
   urc_handler_params_[num_urc_handlers_] = priv;
 
   ++num_urc_handlers_;
@@ -49,7 +48,7 @@ int OwlModemAT::sendData(str data) {
   ssize_t written = 0;
   ssize_t cnt;
   do {
-    cnt = serial_->write((const uint8_t*)data.s+written, data.len-written);
+    cnt = serial_->write((const uint8_t *)data.s + written, data.len - written);
     if (cnt <= 0) {
       LOG(L_ERR, "Had %d bytes to send on modem_port, but wrote only %d.\r\n", data.len, written);
       return 0;
@@ -131,7 +130,8 @@ at_result_code_e OwlModemAT::sendCommand(str command) {
   }
 
   if (in_command_) {
-    LOG(L_ERR, "sendCommand [%.*s] failed: attempt to send while waiting for a response from the previous one\r\n", command.len, command.s);
+    LOG(L_ERR, "sendCommand [%.*s] failed: attempt to send while waiting for a response from the previous one\r\n",
+        command.len, command.s);
     return AT_Result_Code__failure;
   }
 
@@ -151,11 +151,8 @@ at_result_code_e OwlModemAT::sendCommand(str command) {
   return AT_Result_Code__OK;
 }
 
-/*at_result_code_e OwlModemAT::doCommand(str command, uint32_t timeout_millis, str *out_response, int max_response_len) {
-  if (out_response) out_response->len = 0;
-  at_result_code_e result_code;
-  owl_time_t timeout;
-  int received;
+/*at_result_code_e OwlModemAT::doCommand(str command, uint32_t timeout_millis, str *out_response, int max_response_len)
+{ if (out_response) out_response->len = 0; at_result_code_e result_code; owl_time_t timeout; int received;
 
   in_command_ = 1;
   int i;
@@ -211,9 +208,8 @@ failure:
   return AT_Result_Code__failure;
 }
 
-at_result_code_e OwlModemAT::doCommand(char *command, uint32_t timeout_millis, str *out_response, int max_response_len) {
-  str s = {.s = command, .len = strlen(command)};
-  return doCommand(s, timeout_millis, out_response, max_response_len);
+at_result_code_e OwlModemAT::doCommand(char *command, uint32_t timeout_millis, str *out_response, int max_response_len)
+{ str s = {.s = command, .len = strlen(command)}; return doCommand(s, timeout_millis, out_response, max_response_len);
 }*/
 
 at_result_code_e OwlModemAT::getLastCommandResponse(str *out_response, int max_response_len) {
@@ -236,7 +232,8 @@ at_result_code_e OwlModemAT::getLastCommandResponse(str *out_response, int max_r
   }
 }
 
-at_result_code_e OwlModemAT::doCommandBlocking(str command, uint32_t timeout_millis, str *out_response, int max_response_len) {
+at_result_code_e OwlModemAT::doCommandBlocking(str command, uint32_t timeout_millis, str *out_response,
+                                               int max_response_len) {
   owl_time_t timeout;
   int received;
   at_result_code_e result_code;
@@ -279,7 +276,8 @@ at_result_code_e OwlModemAT::doCommandBlocking(str command, uint32_t timeout_mil
   return AT_Result_Code__timeout;
 }
 
-at_result_code_e OwlModemAT::doCommandBlocking(char *command, uint32_t timeout_millis, str *out_response, int max_response_len) {
+at_result_code_e OwlModemAT::doCommandBlocking(char *command, uint32_t timeout_millis, str *out_response,
+                                               int max_response_len) {
   str s = {.s = command, .len = strlen(command)};
   return doCommandBlocking(s, timeout_millis, out_response, max_response_len);
 }
@@ -342,7 +340,7 @@ int OwlModemAT::processURC(str line, int report_unknown) {
   if (line.len < 1 || line.s[0] != '+') return 0;
   int k = str_find_char(line, ": ");
   if (k < 0) return 0;
-  str urc = {.s = line.s, .len = k};
+  str urc  = {.s = line.s, .len = k};
   str data = {.s = line.s + k + 2, .len = line.len - k - 2};
 
   LOG(L_DBG, "URC [%.*s] Data [%.*s]\r\n", urc.len, urc.s, data.len, data.s);
@@ -358,8 +356,8 @@ int OwlModemAT::processURC(str line, int report_unknown) {
   if (this->SIM.processURC(urc, data)) return 1;*/
 
   if (report_unknown) {
-  //  for (int i = 0; prefix_non_urc[i].s; i++)
-  //    if (str_equal(urc, prefix_non_urc[i])) return 0;
+    //  for (int i = 0; prefix_non_urc[i].s; i++)
+    //    if (str_equal(urc, prefix_non_urc[i])) return 0;
     // If it wasn't on the ignored list, report it
     LOG(L_WARN, "Not handled URC [%.*s] with data [%.*s]\r\n", urc.len, urc.s, data.len, data.s);
   }
@@ -477,7 +475,7 @@ int OwlModemAT::drainModemRxToBuffer() {
       rx_buffer.len -= shift;
       memmove(rx_buffer.s, rx_buffer.s + shift, rx_buffer.len);
     }
-    received = serial_->read((uint8_t*)rx_buffer.s + rx_buffer.len, available);
+    received = serial_->read((uint8_t *)rx_buffer.s + rx_buffer.len, available);
     if (received != available) {
       LOG(L_ERR, "modem_port said %d bytes available, but received %d.\r\n", available, received);
       if (received < 0) goto error;
@@ -515,4 +513,3 @@ void OwlModemAT::spin() {
 
   LOG(L_MEM, "Done spinning\r\n");
 }
-

--- a/src/BreakoutSDK/modem/OwlModemAT.h
+++ b/src/BreakoutSDK/modem/OwlModemAT.h
@@ -9,14 +9,18 @@
 
 class OwlModemAT {
  public:
-
-  using UrcHandler = int(*)(str, str, void*); // code, data, private (pointer to the instance normally)
+  using UrcHandler = int (*)(str, str, void *);  // code, data, private (pointer to the instance normally)
   static constexpr int MaxUrcHandlers = 8;
 
-  OwlModemAT(IOwlSerial *serial) : serial_(serial) {}
+  OwlModemAT(IOwlSerial *serial) : serial_(serial) {
+  }
   bool initTerminal();
-  void pause() {paused_ = true;}
-  void resume() {paused_ = false;}
+  void pause() {
+    paused_ = true;
+  }
+  void resume() {
+    paused_ = false;
+  }
 
   /**
    * Send arbitrary data to the modem.
@@ -44,7 +48,9 @@ class OwlModemAT {
    */
   at_result_code_e sendCommand(str command);
   at_result_code_e getLastCommandResponse(str *out_response, int max_response_len);
-  void interrupLastCommand() {in_command_ = false;}
+  void interrupLastCommand() {
+    in_command_ = false;
+  }
   /**
    * Execute one AT command
    * @param command - command to send
@@ -58,7 +64,7 @@ class OwlModemAT {
   at_result_code_e doCommandBlocking(str command, uint32_t timeout_millis, str *out_response, int max_response_len);
   at_result_code_e doCommandBlocking(char *command, uint32_t timeout_millis, str *out_response, int max_response_len);
 
-  bool registerUrcHandler(UrcHandler handler, void* priv);
+  bool registerUrcHandler(UrcHandler handler, void *priv);
   /**
    * Utility function to filter out of the response for a command, lines which do not start with a certain prefix.
    * The prefix is also eliminated, so that you have just your actual data left.
@@ -67,7 +73,9 @@ class OwlModemAT {
    */
   static void filterResponse(str prefix, str *response);
 
-  void interruptLastCommand() {in_command_ = false; }
+  void interruptLastCommand() {
+    in_command_ = false;
+  }
 
 
 
@@ -84,7 +92,7 @@ class OwlModemAT {
   int drainModemRxToBuffer();
 
   UrcHandler urc_handlers_[MaxUrcHandlers];
-  void* urc_handler_params_[MaxUrcHandlers];
+  void *urc_handler_params_[MaxUrcHandlers];
   int num_urc_handlers_{0};
   /** The modem has been issued a command and is waiting for its response - URC are not expected */
   bool in_command_{false};
@@ -98,7 +106,5 @@ class OwlModemAT {
   str response = {.s = response_buffer, .len = 0};
 
   bool paused_{false};
-
-
 };
-#endif // __OWL_MODEM_AT_H__
+#endif  // __OWL_MODEM_AT_H__

--- a/src/BreakoutSDK/modem/OwlModemAT.h
+++ b/src/BreakoutSDK/modem/OwlModemAT.h
@@ -1,0 +1,105 @@
+#ifndef __OWL_MODEM_AT_H__
+#define __OWL_MODEM_AT_H__
+
+#include "IOwlSerial.h"
+#include "enums.h"
+
+#define MODEM_Rx_BUFFER_SIZE 1200
+#define MODEM_RESPONSE_BUFFER_SIZE 1200
+
+class OwlModemAT {
+ public:
+
+  using UrcHandler = int(*)(str, str, void*); // code, data, private (pointer to the instance normally)
+  static constexpr int MaxUrcHandlers = 8;
+
+  OwlModemAT(IOwlSerial *serial) : serial_(serial) {}
+  bool initTerminal();
+  void pause() {paused_ = true;}
+  void resume() {paused_ = false;}
+  void spin();
+
+  /**
+   * Send arbitrary data to the modem.
+   * @param data - data to send
+   * @return 1 on success, 0 on failure
+   */
+  int sendData(str data);
+  int sendData(char *data);
+
+  /**
+   * Call this function periodically, to handle incoming message from the modem. The UART serial interface has a buffer
+   * of just 256 bytes and this function drains it by moving the data to the rx_buffer. What can be parsed (complete
+   * data) is parsed and passed along to handlers.
+   * @return 1 on success, 0 on failure
+   */
+  int handleRxOnTimer();
+
+  /**
+   * Send one AT command
+   *
+   * @param command - command to send
+   * @return AT_Result_Code__OK if the command was sent, negative value otherwise.
+   *   If the command was sent successfully, be sure to either wait for a response
+   *   from getLastCommandResponse or interrupt the waiting with InterruptLastCommand.
+   */
+  at_result_code_e sendCommand(str command);
+  at_result_code_e getLastCommandResponse(str *out_response, int max_response_len);
+  void interrupLastCommand() {in_command_ = false;}
+  /**
+   * Execute one AT command
+   * @param command - command to send
+   * @param timeout_millis - timeout for the command in milliseconds - consult the modem manual for maximum timeouts
+   * for each command
+   * @param out_response - optional output buffer to fill with the command response (not including the result code)
+   * @param max_response_len - length of output buffer
+   * @return the AT result code, or AT_Result_Code__failure on failure to send the data, or AT_Result_Code__timeout in
+   * case of timeout while waiting for one of the standard AT result codes.
+   */
+  at_result_code_e doCommandBlocking(str command, uint32_t timeout_millis, str *out_response, int max_response_len);
+  at_result_code_e doCommandBlocking(char *command, uint32_t timeout_millis, str *out_response, int max_response_len);
+
+  bool registerUrcHandler(UrcHandler handler, void* priv);
+  /**
+   * Utility function to filter out of the response for a command, lines which do not start with a certain prefix.
+   * The prefix is also eliminated, so that you have just your actual data left.
+   * @param prefix - prefix to take out
+   * @param out_response - response to modify
+   */
+  static void filterResponse(str prefix, str *response);
+
+  void interruptLastCommand() {in_command_ = false; }
+
+
+
+ private:
+  IOwlSerial *serial_;
+
+  int processURC(str line, int report_unknown);
+  int getNextCompleteLine(int start_idx, str *line);
+  void removeRxBufferLine(str line);
+  void consumeUnsolicited();
+  void consumeUnsolicitedInCommandResponse();
+  at_result_code_e extractResult(str *out_response, int max_response_len);
+
+  int drainModemRxToBuffer();
+
+  UrcHandler urc_handlers_[MaxUrcHandlers];
+  void* urc_handler_params_[MaxUrcHandlers];
+  int num_urc_handlers_{0};
+  /** The modem has been issued a command and is waiting for its response - URC are not expected */
+  bool in_command_{false};
+
+  /** The receiving buffer - the modem interface is drained and bytes moved here */
+  char c_rx_buffer[MODEM_Rx_BUFFER_SIZE];
+  str rx_buffer = {.s = c_rx_buffer, .len = 0};
+
+  /** Response buffer, to be used by the internal functions */
+  char response_buffer[MODEM_RESPONSE_BUFFER_SIZE];
+  str response = {.s = response_buffer, .len = 0};
+
+  bool paused_{false};
+
+
+};
+#endif // __OWL_MODEM_AT_H__

--- a/src/BreakoutSDK/modem/OwlModemAT.h
+++ b/src/BreakoutSDK/modem/OwlModemAT.h
@@ -17,7 +17,6 @@ class OwlModemAT {
   bool initTerminal();
   void pause() {paused_ = true;}
   void resume() {paused_ = false;}
-  void spin();
 
   /**
    * Send arbitrary data to the modem.
@@ -33,7 +32,7 @@ class OwlModemAT {
    * data) is parsed and passed along to handlers.
    * @return 1 on success, 0 on failure
    */
-  int handleRxOnTimer();
+  void spin();
 
   /**
    * Send one AT command

--- a/src/BreakoutSDK/modem/OwlModemGNSS.cpp
+++ b/src/BreakoutSDK/modem/OwlModemGNSS.cpp
@@ -164,11 +164,12 @@ int OwlModemGNSS::getGNSSData(gnss_data_t *out_data) {
 void OwlModemGNSS::logGNSSData(log_level_t level, gnss_data_t data) {
   if (!owl_log_is_printable(level)) return;
   LOG(level, "GNSS Data:  data_valid %s  mode_indicator %c(%s)\r\n", data.valid ? "yes" : "no", data.mode_indicator,
-      data.mode_indicator == 'N' ? "Data not valid" : data.mode_indicator == 'A' ?
-                                   "Autonomous mode" :
-                                   data.mode_indicator == 'D' ? "Differential mode" : data.mode_indicator == 'E' ?
-                                                                "Estimated (dead reckoning) mode" :
-                                                                "<unknown>");
+      data.mode_indicator == 'N' ?
+          "Data not valid" :
+          data.mode_indicator == 'A' ?
+          "Autonomous mode" :
+          data.mode_indicator == 'D' ? "Differential mode" :
+                                       data.mode_indicator == 'E' ? "Estimated (dead reckoning) mode" : "<unknown>");
   if (data.valid) {
     LOG(level, "  - Position:  %d %7.5f %s  %d %7.5f %s\r\n", data.position.latitude_degrees,
         data.position.latitude_minutes, data.position.is_north ? "N" : "S", data.position.longitude_degrees,

--- a/src/BreakoutSDK/modem/OwlModemGNSS.h
+++ b/src/BreakoutSDK/modem/OwlModemGNSS.h
@@ -70,8 +70,8 @@ typedef struct {
 } gnss_data_t;
 
 /**
-* Twilio wrapper for the serial interface to a GNSS module
-*/
+ * Twilio wrapper for the serial interface to a GNSS module
+ */
 class OwlModemGNSS {
  public:
   OwlModemGNSS(OwlModem *owlModem);

--- a/src/BreakoutSDK/modem/OwlModemInformation.cpp
+++ b/src/BreakoutSDK/modem/OwlModemInformation.cpp
@@ -25,44 +25,42 @@
 
 #include "OwlModem.h"
 
-
-
-OwlModemInformation::OwlModemInformation(OwlModem *owlModem) : owlModem(owlModem) {
+OwlModemInformation::OwlModemInformation(OwlModemAT *atModem) : atModem_(atModem) {
 }
 
 
 int OwlModemInformation::getProductIdentification(str *out_response, int max_response_len) {
   if (out_response) out_response->len = 0;
-  return owlModem->doCommand("ATI", 1000, out_response, max_response_len) == AT_Result_Code__OK;
+  return atModem_->doCommandBlocking("ATI", 1000, out_response, max_response_len) == AT_Result_Code__OK;
 }
 
 int OwlModemInformation::getManufacturer(str *out_response, int max_response_len) {
   if (out_response) out_response->len = 0;
-  return owlModem->doCommand("AT+CGMI", 1000, out_response, max_response_len) == AT_Result_Code__OK;
+  return atModem_->doCommandBlocking("AT+CGMI", 1000, out_response, max_response_len) == AT_Result_Code__OK;
 }
 
 int OwlModemInformation::getModel(str *out_response, int max_response_len) {
   if (out_response) out_response->len = 0;
-  return owlModem->doCommand("AT+CGMM", 1000, out_response, max_response_len) == AT_Result_Code__OK;
+  return atModem_->doCommandBlocking("AT+CGMM", 1000, out_response, max_response_len) == AT_Result_Code__OK;
 }
 
 int OwlModemInformation::getVersion(str *out_response, int max_response_len) {
   if (out_response) out_response->len = 0;
-  return owlModem->doCommand("AT+CGMR", 1000, out_response, max_response_len) == AT_Result_Code__OK;
+  return atModem_->doCommandBlocking("AT+CGMR", 1000, out_response, max_response_len) == AT_Result_Code__OK;
 }
 
 int OwlModemInformation::getIMEI(str *out_response, int max_response_len) {
   if (out_response) out_response->len = 0;
-  return owlModem->doCommand("AT+CGSN", 1000, out_response, max_response_len) == AT_Result_Code__OK;
+  return atModem_->doCommandBlocking("AT+CGSN", 1000, out_response, max_response_len) == AT_Result_Code__OK;
 }
 
 static str s_cbc = STRDECL("+CBC: ");
 
 int OwlModemInformation::getBatteryChargeLevels(str *out_response, int max_response_len) {
   if (out_response) out_response->len = 0;
-  int result = owlModem->doCommand("AT+CBC", 1000, out_response, max_response_len) == AT_Result_Code__OK;
+  int result = atModem_->doCommandBlocking("AT+CBC", 1000, out_response, max_response_len) == AT_Result_Code__OK;
   if (!result) return 0;
-  owlModem->filterResponse(s_cbc, out_response);
+  OwlModemAT::filterResponse(s_cbc, out_response);
   return 1;
 }
 
@@ -70,16 +68,16 @@ static str s_cind = STRDECL("+CIND: ");
 
 int OwlModemInformation::getIndicators(str *out_response, int max_response_len) {
   if (out_response) out_response->len = 0;
-  int result = owlModem->doCommand("AT+CIND?", 1000, out_response, max_response_len) == AT_Result_Code__OK;
+  int result = atModem_->doCommandBlocking("AT+CIND?", 1000, out_response, max_response_len) == AT_Result_Code__OK;
   if (!result) return 0;
-  owlModem->filterResponse(s_cind, out_response);
+  OwlModemAT::filterResponse(s_cind, out_response);
   return 1;
 }
 
 int OwlModemInformation::getIndicatorsHelp(str *out_response, int max_response_len) {
   if (out_response) out_response->len = 0;
-  int result = owlModem->doCommand("AT+CIND=?", 1000, out_response, max_response_len) == AT_Result_Code__OK;
+  int result = atModem_->doCommandBlocking("AT+CIND=?", 1000, out_response, max_response_len) == AT_Result_Code__OK;
   if (!result) return 0;
-  owlModem->filterResponse(s_cind, out_response);
+  OwlModemAT::filterResponse(s_cind, out_response);
   return 1;
 }

--- a/src/BreakoutSDK/modem/OwlModemInformation.h
+++ b/src/BreakoutSDK/modem/OwlModemInformation.h
@@ -25,18 +25,14 @@
 #define __OWL_MODEM_INFORMATION_H__
 
 #include "enums.h"
-
-
-
-class OwlModem;
-
+#include "OwlModemAT.h"
 
 /**
  * Twilio wrapper for the AT serial interface to a modem - Methods to get information from the modem
  */
 class OwlModemInformation {
  public:
-  OwlModemInformation(OwlModem *owlModem);
+  OwlModemInformation(OwlModemAT *atModem);
 
   /*
    * Methods to get information from the modem or SIM card
@@ -110,7 +106,7 @@ class OwlModemInformation {
 
 
  private:
-  OwlModem *owlModem = 0;
+  OwlModemAT *atModem_ = 0;
 };
 
 #endif

--- a/src/BreakoutSDK/modem/OwlModemNetwork.cpp
+++ b/src/BreakoutSDK/modem/OwlModemNetwork.cpp
@@ -29,7 +29,10 @@
 
 
 
-OwlModemNetwork::OwlModemNetwork(OwlModem *owlModem) : owlModem(owlModem) {
+OwlModemNetwork::OwlModemNetwork(OwlModemAT *atModem) : atModem_(atModem) {
+  if(atModem_ != nullptr) {
+    atModem_-> registerUrcHandler(OwlModemNetwork::processURC, this);
+  }
 }
 
 
@@ -260,10 +263,12 @@ int OwlModemNetwork::processURCEPSRegistration(str urc, str data) {
 
 
 
-int OwlModemNetwork::processURC(str urc, str data) {
-  if (processURCNetworkRegistration(urc, data)) return 1;
-  if (processURCGPRSRegistration(urc, data)) return 1;
-  if (processURCEPSRegistration(urc, data)) return 1;
+int OwlModemNetwork::processURC(str urc, str data, void* instance) {
+  OwlModemNetwork *inst = reinterpret_cast<OwlModemNetwork*>(instance);
+
+  if (inst->processURCNetworkRegistration(urc, data)) return 1;
+  if (inst->processURCGPRSRegistration(urc, data)) return 1;
+  if (inst->processURCEPSRegistration(urc, data)) return 1;
   return 0;
 }
 
@@ -274,10 +279,10 @@ static str s_cfun = STRDECL("+CFUN: ");
 int OwlModemNetwork::getModemFunctionality(at_cfun_power_mode_e *out_power_mode, at_cfun_stk_mode_e *out_stk_mode) {
   if (out_power_mode) *out_power_mode = AT_CFUN__POWER_MODE__Minimum_Functionality;
   if (out_stk_mode) *out_stk_mode     = AT_CFUN__STK_MODE__Interface_Disabled_Proactive_SIM_APPL_Enabled_0;
-  int result = owlModem->doCommand("AT+CFUN?", 15 * 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
+  int result = atModem_->doCommandBlocking("AT+CFUN?", 15 * 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
                AT_Result_Code__OK;
   if (!result) return 0;
-  owlModem->filterResponse(s_cfun, &network_response);
+  OwlModemAT::filterResponse(s_cfun, &network_response);
   str token = {0};
   int cnt   = 0;
   while (str_tok(network_response, ",\r\n", &token)) {
@@ -302,7 +307,7 @@ int OwlModemNetwork::setModemFunctionality(at_cfun_fun_e fun, at_cfun_rst_e *res
     snprintf(buffer, 64, "AT+CFUN=%d", fun);
   else
     snprintf(buffer, 64, "AT+CFUN=%d,%d", fun, *reset);
-  return owlModem->doCommand(buffer, 3 * 60 * 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
+  return atModem_->doCommandBlocking(buffer, 3 * 60 * 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
          AT_Result_Code__OK;
 }
 
@@ -312,10 +317,10 @@ static str s_umnoprof = STRDECL("+UMNOPROF: ");
 
 int OwlModemNetwork::getModemMNOProfile(at_umnoprof_mno_profile_e *out_profile) {
   if (out_profile) *out_profile = AT_UMNOPROF__MNO_PROFILE__SW_Default;
-  int result = owlModem->doCommand("AT+UMNOPROF?", 15 * 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
+  int result = atModem_->doCommandBlocking("AT+UMNOPROF?", 15 * 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
                AT_Result_Code__OK;
   if (!result) return 0;
-  owlModem->filterResponse(s_umnoprof, &network_response);
+  OwlModemAT::filterResponse(s_umnoprof, &network_response);
   *out_profile = (at_umnoprof_mno_profile_e)str_to_long_int(network_response, 10);
   return 1;
 }
@@ -323,7 +328,7 @@ int OwlModemNetwork::getModemMNOProfile(at_umnoprof_mno_profile_e *out_profile) 
 int OwlModemNetwork::setModemMNOProfile(at_umnoprof_mno_profile_e profile) {
   char buffer[64];
   snprintf(buffer, 64, "AT+UMNOPROF=%d", profile);
-  return owlModem->doCommand(buffer, 3 * 60 * 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
+  return atModem_->doCommandBlocking(buffer, 3 * 60 * 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
          AT_Result_Code__OK;
 }
 
@@ -339,10 +344,10 @@ int OwlModemNetwork::getOperatorSelection(at_cops_mode_e *out_mode, at_cops_form
   if (out_format) *out_format = AT_COPS__Format__Long_Alphanumeric;
   if (out_oper) out_oper->len = 0;
   if (out_act) *out_act       = (at_cops_act_e)0;
-  int result = owlModem->doCommand("AT+COPS?", 3 * 60 * 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
+  int result = atModem_->doCommandBlocking("AT+COPS?", 3 * 60 * 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
                AT_Result_Code__OK;
   if (!result) return 0;
-  owlModem->filterResponse(s_cops, &network_response);
+  OwlModemAT::filterResponse(s_cops, &network_response);
   while (str_tok(network_response, ",\r\n", &token)) {
     switch (cnt) {
       case 0:
@@ -388,7 +393,7 @@ int OwlModemNetwork::setOperatorSelection(at_cops_mode_e mode, at_cops_format_e 
   } else {
     snprintf(buf, 64, "AT+COPS=%d", mode);
   }
-  int result = owlModem->doCommand(buf, 3 * 60 * 1000, 0, 0) == AT_Result_Code__OK;
+  int result = atModem_->doCommandBlocking(buf, 3 * 60 * 1000, 0, 0) == AT_Result_Code__OK;
   if (!result) return 0;
   return 1;
 }
@@ -397,9 +402,9 @@ int OwlModemNetwork::getOperatorList(str *out_response, int max_response_len) {
   // TODO - parse maybe the structures. But then we'll have a more complex list structure, which should be freed by
   // the user, so more complex to use.
   if (out_response) out_response->len = 0;
-  int result = owlModem->doCommand("AT+COPS=?", 3 * 60 * 1000, out_response, max_response_len) == AT_Result_Code__OK;
+  int result = atModem_->doCommandBlocking("AT+COPS=?", 3 * 60 * 1000, out_response, max_response_len) == AT_Result_Code__OK;
   if (!result) return 0;
-  owlModem->filterResponse(s_cops, out_response);
+  OwlModemAT::filterResponse(s_cops, out_response);
   return 1;
 }
 
@@ -412,7 +417,7 @@ int OwlModemNetwork::getNetworkRegistrationStatus(at_creg_n_e *out_n, at_creg_st
   if (out_lac) *out_lac   = 0;
   if (out_ci) *out_ci     = 0xFFFFFFFFu;
   if (out_act) *out_act   = AT_CREG__AcT__invalid;
-  int result = owlModem->doCommand("AT+CREG?", 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
+  int result = atModem_->doCommandBlocking("AT+CREG?", 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
                AT_Result_Code__OK;
   if (!result) return 0;
   // the URC handlers are catching this, so serving from local cache
@@ -427,7 +432,7 @@ int OwlModemNetwork::getNetworkRegistrationStatus(at_creg_n_e *out_n, at_creg_st
 int OwlModemNetwork::setNetworkRegistrationURC(at_creg_n_e n) {
   char buf[64];
   snprintf(buf, 64, "AT+CREG=%d", n);
-  return owlModem->doCommand(buf, 180000, 0, 0) == AT_Result_Code__OK;
+  return atModem_->doCommandBlocking(buf, 180000, 0, 0) == AT_Result_Code__OK;
 }
 
 void OwlModemNetwork::setHandlerNetworkRegistrationURC(OwlModem_NetworkRegistrationStatusChangeHandler_f cb) {
@@ -443,7 +448,7 @@ int OwlModemNetwork::getGPRSRegistrationStatus(at_cgreg_n_e *out_n, at_cgreg_sta
   if (out_ci) *out_ci     = 0xFFFFFFFFu;
   if (out_act) *out_act   = AT_CGREG__AcT__invalid;
   if (out_rac) *out_rac   = 0;
-  int result = owlModem->doCommand("AT+CGREG?", 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
+  int result = atModem_->doCommandBlocking("AT+CGREG?", 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
                AT_Result_Code__OK;
   if (!result) return 0;
   // the URC handlers are catching this, so serving from local cache
@@ -459,7 +464,7 @@ int OwlModemNetwork::getGPRSRegistrationStatus(at_cgreg_n_e *out_n, at_cgreg_sta
 int OwlModemNetwork::setGPRSRegistrationURC(at_cgreg_n_e n) {
   char buf[64];
   snprintf(buf, 64, "AT+CGREG=%d", n);
-  return owlModem->doCommand(buf, 180000, 0, 0) == AT_Result_Code__OK;
+  return atModem_->doCommandBlocking(buf, 180000, 0, 0) == AT_Result_Code__OK;
 }
 
 void OwlModemNetwork::setHandlerGPRSRegistrationURC(OwlModem_GPRSRegistrationStatusChangeHandler_f cb) {
@@ -476,7 +481,7 @@ int OwlModemNetwork::getEPSRegistrationStatus(at_cereg_n_e *out_n, at_cereg_stat
   if (out_act) *out_act                   = AT_CEREG__AcT__invalid;
   if (out_cause_type) *out_cause_type     = AT_CEREG__Cause_Type__EMM_Cause;
   if (out_reject_cause) *out_reject_cause = 0;
-  int result = owlModem->doCommand("AT+CEREG?", 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
+  int result = atModem_->doCommandBlocking("AT+CEREG?", 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
                AT_Result_Code__OK;
   if (!result) return 0;
   // the URC handlers are catching this, so serving from local cache
@@ -493,7 +498,7 @@ int OwlModemNetwork::getEPSRegistrationStatus(at_cereg_n_e *out_n, at_cereg_stat
 int OwlModemNetwork::setEPSRegistrationURC(at_cereg_n_e n) {
   char buf[64];
   snprintf(buf, 64, "AT+CEREG=%d", n);
-  return owlModem->doCommand(buf, 180000, 0, 0) == AT_Result_Code__OK;
+  return atModem_->doCommandBlocking(buf, 180000, 0, 0) == AT_Result_Code__OK;
 }
 
 void OwlModemNetwork::setHandlerEPSRegistrationURC(OwlModem_EPSRegistrationStatusChangeHandler_f cb) {
@@ -511,9 +516,9 @@ int OwlModemNetwork::getSignalQuality(at_csq_rssi_e *out_rssi, at_csq_qual_e *ou
   if (out_rssi) *out_rssi = AT_CSQ__RSSI__Not_Known_or_Detectable_99;
   if (out_qual) *out_qual = AT_CSQ__Qual__Not_Known_or_Not_Detectable;
   int result =
-      owlModem->doCommand("AT+CSQ", 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) == AT_Result_Code__OK;
+      atModem_->doCommandBlocking("AT+CSQ", 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) == AT_Result_Code__OK;
   if (!result) return 0;
-  owlModem->filterResponse(s_csq, &network_response);
+  OwlModemAT::filterResponse(s_csq, &network_response);
   while (str_tok(network_response, ",", &token)) {
     switch (cnt) {
       case 0:

--- a/src/BreakoutSDK/modem/OwlModemNetwork.cpp
+++ b/src/BreakoutSDK/modem/OwlModemNetwork.cpp
@@ -35,8 +35,6 @@ OwlModemNetwork::OwlModemNetwork(OwlModemAT *atModem) : atModem_(atModem) {
   }
 }
 
-
-
 static str s_creg      = STRDECL("+CREG");
 static str s_creg_full = STRDECL("+CREG: ");
 

--- a/src/BreakoutSDK/modem/OwlModemNetwork.cpp
+++ b/src/BreakoutSDK/modem/OwlModemNetwork.cpp
@@ -384,9 +384,9 @@ int OwlModemNetwork::setOperatorSelection(at_cops_mode_e mode, at_cops_format_e 
   char buf[64];
   if (opt_oper) {
     if (opt_act) {
-      snprintf(buf, 64, "AT+COPS=%d,%d,%.*s,%d", mode, *opt_format, opt_oper->len, opt_oper->s, *opt_act);
+      snprintf(buf, 64, "AT+COPS=%d,%d,\"%.*s\",%d", mode, *opt_format, opt_oper->len, opt_oper->s, *opt_act);
     } else {
-      snprintf(buf, 64, "AT+COPS=%d,%d,%.*s", mode, *opt_format, opt_oper->len, opt_oper->s);
+      snprintf(buf, 64, "AT+COPS=%d,%d,\"%.*s\"", mode, *opt_format, opt_oper->len, opt_oper->s);
     }
   } else {
     snprintf(buf, 64, "AT+COPS=%d", mode);

--- a/src/BreakoutSDK/modem/OwlModemNetwork.cpp
+++ b/src/BreakoutSDK/modem/OwlModemNetwork.cpp
@@ -30,8 +30,8 @@
 
 
 OwlModemNetwork::OwlModemNetwork(OwlModemAT *atModem) : atModem_(atModem) {
-  if(atModem_ != nullptr) {
-    atModem_-> registerUrcHandler(OwlModemNetwork::processURC, this);
+  if (atModem_ != nullptr) {
+    atModem_->registerUrcHandler(OwlModemNetwork::processURC, this);
   }
 }
 
@@ -42,13 +42,13 @@ static str s_creg_full = STRDECL("+CREG: ");
 
 void OwlModemNetwork::parseNetworkRegistrationStatus(str response, at_creg_n_e *out_n, at_creg_stat_e *out_stat,
                                                      uint16_t *out_lac, uint32_t *out_ci, at_creg_act_e *out_act) {
-  int cnt                 = 0;
-  str token               = {0};
-  if (out_n) *out_n       = AT_CREG__N__URC_Disabled;
+  int cnt   = 0;
+  str token = {0};
+  if (out_n) *out_n = AT_CREG__N__URC_Disabled;
   if (out_stat) *out_stat = AT_CREG__Stat__Not_Registered;
-  if (out_lac) *out_lac   = 0;
-  if (out_ci) *out_ci     = 0xFFFFFFFFu;
-  if (out_act) *out_act   = AT_CREG__AcT__invalid;
+  if (out_lac) *out_lac = 0;
+  if (out_ci) *out_ci = 0xFFFFFFFFu;
+  if (out_act) *out_act = AT_CREG__AcT__invalid;
 
   str data = response;
   str_skipover_prefix(&data, s_creg_full);
@@ -114,14 +114,14 @@ static str s_cgreg_full = STRDECL("+CGREG: ");
 void OwlModemNetwork::parseGPRSRegistrationStatus(str response, at_cgreg_n_e *out_n, at_cgreg_stat_e *out_stat,
                                                   uint16_t *out_lac, uint32_t *out_ci, at_cgreg_act_e *out_act,
                                                   uint8_t *out_rac) {
-  int cnt                 = 0;
-  str token               = {0};
-  if (out_n) *out_n       = AT_CGREG__N__URC_Disabled;
+  int cnt   = 0;
+  str token = {0};
+  if (out_n) *out_n = AT_CGREG__N__URC_Disabled;
   if (out_stat) *out_stat = AT_CGREG__Stat__Not_Registered;
-  if (out_lac) *out_lac   = 0;
-  if (out_ci) *out_ci     = 0xFFFFFFFFu;
-  if (out_act) *out_act   = AT_CGREG__AcT__invalid;
-  if (out_rac) *out_rac   = 0;
+  if (out_lac) *out_lac = 0;
+  if (out_ci) *out_ci = 0xFFFFFFFFu;
+  if (out_act) *out_act = AT_CGREG__AcT__invalid;
+  if (out_rac) *out_rac = 0;
 
   str data = response;
   str_skipover_prefix(&data, s_cgreg_full);
@@ -189,14 +189,14 @@ static str s_cereg_full = STRDECL("+CEREG: ");
 void OwlModemNetwork::parseEPSRegistrationStatus(str response, at_cereg_n_e *out_n, at_cereg_stat_e *out_stat,
                                                  uint16_t *out_lac, uint32_t *out_ci, at_cereg_act_e *out_act,
                                                  at_cereg_cause_type_e *out_cause_type, uint32_t *out_reject_cause) {
-  int cnt                                 = 0;
-  str token                               = {0};
-  if (out_n) *out_n                       = AT_CEREG__N__URC_Disabled;
-  if (out_stat) *out_stat                 = AT_CEREG__Stat__Not_Registered;
-  if (out_lac) *out_lac                   = 0;
-  if (out_ci) *out_ci                     = 0xFFFFFFFFu;
-  if (out_act) *out_act                   = AT_CEREG__AcT__invalid;
-  if (out_cause_type) *out_cause_type     = AT_CEREG__Cause_Type__EMM_Cause;
+  int cnt   = 0;
+  str token = {0};
+  if (out_n) *out_n = AT_CEREG__N__URC_Disabled;
+  if (out_stat) *out_stat = AT_CEREG__Stat__Not_Registered;
+  if (out_lac) *out_lac = 0;
+  if (out_ci) *out_ci = 0xFFFFFFFFu;
+  if (out_act) *out_act = AT_CEREG__AcT__invalid;
+  if (out_cause_type) *out_cause_type = AT_CEREG__Cause_Type__EMM_Cause;
   if (out_reject_cause) *out_reject_cause = 0;
 
   str data = response;
@@ -263,8 +263,8 @@ int OwlModemNetwork::processURCEPSRegistration(str urc, str data) {
 
 
 
-int OwlModemNetwork::processURC(str urc, str data, void* instance) {
-  OwlModemNetwork *inst = reinterpret_cast<OwlModemNetwork*>(instance);
+int OwlModemNetwork::processURC(str urc, str data, void *instance) {
+  OwlModemNetwork *inst = reinterpret_cast<OwlModemNetwork *>(instance);
 
   if (inst->processURCNetworkRegistration(urc, data)) return 1;
   if (inst->processURCGPRSRegistration(urc, data)) return 1;
@@ -278,9 +278,9 @@ static str s_cfun = STRDECL("+CFUN: ");
 
 int OwlModemNetwork::getModemFunctionality(at_cfun_power_mode_e *out_power_mode, at_cfun_stk_mode_e *out_stk_mode) {
   if (out_power_mode) *out_power_mode = AT_CFUN__POWER_MODE__Minimum_Functionality;
-  if (out_stk_mode) *out_stk_mode     = AT_CFUN__STK_MODE__Interface_Disabled_Proactive_SIM_APPL_Enabled_0;
-  int result = atModem_->doCommandBlocking("AT+CFUN?", 15 * 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
-               AT_Result_Code__OK;
+  if (out_stk_mode) *out_stk_mode = AT_CFUN__STK_MODE__Interface_Disabled_Proactive_SIM_APPL_Enabled_0;
+  int result = atModem_->doCommandBlocking("AT+CFUN?", 15 * 1000, &network_response,
+                                           MODEM_NETWORK_RESPONSE_BUFFER_SIZE) == AT_Result_Code__OK;
   if (!result) return 0;
   OwlModemAT::filterResponse(s_cfun, &network_response);
   str token = {0};
@@ -317,8 +317,8 @@ static str s_umnoprof = STRDECL("+UMNOPROF: ");
 
 int OwlModemNetwork::getModemMNOProfile(at_umnoprof_mno_profile_e *out_profile) {
   if (out_profile) *out_profile = AT_UMNOPROF__MNO_PROFILE__SW_Default;
-  int result = atModem_->doCommandBlocking("AT+UMNOPROF?", 15 * 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
-               AT_Result_Code__OK;
+  int result = atModem_->doCommandBlocking("AT+UMNOPROF?", 15 * 1000, &network_response,
+                                           MODEM_NETWORK_RESPONSE_BUFFER_SIZE) == AT_Result_Code__OK;
   if (!result) return 0;
   OwlModemAT::filterResponse(s_umnoprof, &network_response);
   *out_profile = (at_umnoprof_mno_profile_e)str_to_long_int(network_response, 10);
@@ -337,15 +337,15 @@ static str s_cops = STRDECL("+COPS: ");
 
 int OwlModemNetwork::getOperatorSelection(at_cops_mode_e *out_mode, at_cops_format_e *out_format, str *out_oper,
                                           int max_oper_len, at_cops_act_e *out_act) {
-  int cnt                     = 0;
-  str token                   = {0};
-  char save                   = 0;
-  if (out_mode) *out_mode     = AT_COPS__Mode__Automatic_Selection;
+  int cnt   = 0;
+  str token = {0};
+  char save = 0;
+  if (out_mode) *out_mode = AT_COPS__Mode__Automatic_Selection;
   if (out_format) *out_format = AT_COPS__Format__Long_Alphanumeric;
   if (out_oper) out_oper->len = 0;
-  if (out_act) *out_act       = (at_cops_act_e)0;
-  int result = atModem_->doCommandBlocking("AT+COPS?", 3 * 60 * 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
-               AT_Result_Code__OK;
+  if (out_act) *out_act = (at_cops_act_e)0;
+  int result = atModem_->doCommandBlocking("AT+COPS?", 3 * 60 * 1000, &network_response,
+                                           MODEM_NETWORK_RESPONSE_BUFFER_SIZE) == AT_Result_Code__OK;
   if (!result) return 0;
   OwlModemAT::filterResponse(s_cops, &network_response);
   while (str_tok(network_response, ",\r\n", &token)) {
@@ -402,7 +402,8 @@ int OwlModemNetwork::getOperatorList(str *out_response, int max_response_len) {
   // TODO - parse maybe the structures. But then we'll have a more complex list structure, which should be freed by
   // the user, so more complex to use.
   if (out_response) out_response->len = 0;
-  int result = atModem_->doCommandBlocking("AT+COPS=?", 3 * 60 * 1000, out_response, max_response_len) == AT_Result_Code__OK;
+  int result =
+      atModem_->doCommandBlocking("AT+COPS=?", 3 * 60 * 1000, out_response, max_response_len) == AT_Result_Code__OK;
   if (!result) return 0;
   OwlModemAT::filterResponse(s_cops, out_response);
   return 1;
@@ -412,20 +413,20 @@ int OwlModemNetwork::getOperatorList(str *out_response, int max_response_len) {
 
 int OwlModemNetwork::getNetworkRegistrationStatus(at_creg_n_e *out_n, at_creg_stat_e *out_stat, uint16_t *out_lac,
                                                   uint32_t *out_ci, at_creg_act_e *out_act) {
-  if (out_n) *out_n       = AT_CREG__N__URC_Disabled;
+  if (out_n) *out_n = AT_CREG__N__URC_Disabled;
   if (out_stat) *out_stat = AT_CREG__Stat__Not_Registered;
-  if (out_lac) *out_lac   = 0;
-  if (out_ci) *out_ci     = 0xFFFFFFFFu;
-  if (out_act) *out_act   = AT_CREG__AcT__invalid;
+  if (out_lac) *out_lac = 0;
+  if (out_ci) *out_ci = 0xFFFFFFFFu;
+  if (out_act) *out_act = AT_CREG__AcT__invalid;
   int result = atModem_->doCommandBlocking("AT+CREG?", 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
                AT_Result_Code__OK;
   if (!result) return 0;
   // the URC handlers are catching this, so serving from local cache
-  if (out_n) *out_n       = last_network_status.n;
+  if (out_n) *out_n = last_network_status.n;
   if (out_stat) *out_stat = last_network_status.stat;
-  if (out_lac) *out_lac   = last_network_status.lac;
-  if (out_ci) *out_ci     = last_network_status.ci;
-  if (out_act) *out_act   = last_network_status.act;
+  if (out_lac) *out_lac = last_network_status.lac;
+  if (out_ci) *out_ci = last_network_status.ci;
+  if (out_act) *out_act = last_network_status.act;
   return 1;
 }
 
@@ -442,22 +443,22 @@ void OwlModemNetwork::setHandlerNetworkRegistrationURC(OwlModem_NetworkRegistrat
 
 int OwlModemNetwork::getGPRSRegistrationStatus(at_cgreg_n_e *out_n, at_cgreg_stat_e *out_stat, uint16_t *out_lac,
                                                uint32_t *out_ci, at_cgreg_act_e *out_act, uint8_t *out_rac) {
-  if (out_n) *out_n       = AT_CGREG__N__URC_Disabled;
+  if (out_n) *out_n = AT_CGREG__N__URC_Disabled;
   if (out_stat) *out_stat = AT_CGREG__Stat__Not_Registered;
-  if (out_lac) *out_lac   = 0;
-  if (out_ci) *out_ci     = 0xFFFFFFFFu;
-  if (out_act) *out_act   = AT_CGREG__AcT__invalid;
-  if (out_rac) *out_rac   = 0;
+  if (out_lac) *out_lac = 0;
+  if (out_ci) *out_ci = 0xFFFFFFFFu;
+  if (out_act) *out_act = AT_CGREG__AcT__invalid;
+  if (out_rac) *out_rac = 0;
   int result = atModem_->doCommandBlocking("AT+CGREG?", 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
                AT_Result_Code__OK;
   if (!result) return 0;
   // the URC handlers are catching this, so serving from local cache
-  if (out_n) *out_n       = last_gprs_status.n;
+  if (out_n) *out_n = last_gprs_status.n;
   if (out_stat) *out_stat = last_gprs_status.stat;
-  if (out_lac) *out_lac   = last_gprs_status.lac;
-  if (out_ci) *out_ci     = last_gprs_status.ci;
-  if (out_act) *out_act   = last_gprs_status.act;
-  if (out_act) *out_rac   = last_gprs_status.rac;
+  if (out_lac) *out_lac = last_gprs_status.lac;
+  if (out_ci) *out_ci = last_gprs_status.ci;
+  if (out_act) *out_act = last_gprs_status.act;
+  if (out_act) *out_rac = last_gprs_status.rac;
   return 1;
 }
 
@@ -474,23 +475,23 @@ void OwlModemNetwork::setHandlerGPRSRegistrationURC(OwlModem_GPRSRegistrationSta
 int OwlModemNetwork::getEPSRegistrationStatus(at_cereg_n_e *out_n, at_cereg_stat_e *out_stat, uint16_t *out_lac,
                                               uint32_t *out_ci, at_cereg_act_e *out_act,
                                               at_cereg_cause_type_e *out_cause_type, uint32_t *out_reject_cause) {
-  if (out_n) *out_n                       = AT_CEREG__N__URC_Disabled;
-  if (out_stat) *out_stat                 = AT_CEREG__Stat__Not_Registered;
-  if (out_lac) *out_lac                   = 0;
-  if (out_ci) *out_ci                     = 0xFFFFFFFFu;
-  if (out_act) *out_act                   = AT_CEREG__AcT__invalid;
-  if (out_cause_type) *out_cause_type     = AT_CEREG__Cause_Type__EMM_Cause;
+  if (out_n) *out_n = AT_CEREG__N__URC_Disabled;
+  if (out_stat) *out_stat = AT_CEREG__Stat__Not_Registered;
+  if (out_lac) *out_lac = 0;
+  if (out_ci) *out_ci = 0xFFFFFFFFu;
+  if (out_act) *out_act = AT_CEREG__AcT__invalid;
+  if (out_cause_type) *out_cause_type = AT_CEREG__Cause_Type__EMM_Cause;
   if (out_reject_cause) *out_reject_cause = 0;
   int result = atModem_->doCommandBlocking("AT+CEREG?", 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
                AT_Result_Code__OK;
   if (!result) return 0;
   // the URC handlers are catching this, so serving from local cache
-  if (out_n) *out_n                       = last_eps_status.n;
-  if (out_stat) *out_stat                 = last_eps_status.stat;
-  if (out_lac) *out_lac                   = last_eps_status.lac;
-  if (out_ci) *out_ci                     = last_eps_status.ci;
-  if (out_act) *out_act                   = last_eps_status.act;
-  if (out_cause_type) *out_cause_type     = last_eps_status.cause_type;
+  if (out_n) *out_n = last_eps_status.n;
+  if (out_stat) *out_stat = last_eps_status.stat;
+  if (out_lac) *out_lac = last_eps_status.lac;
+  if (out_ci) *out_ci = last_eps_status.ci;
+  if (out_act) *out_act = last_eps_status.act;
+  if (out_cause_type) *out_cause_type = last_eps_status.cause_type;
   if (out_reject_cause) *out_reject_cause = last_eps_status.reject_cause;
   return 1;
 }
@@ -510,13 +511,13 @@ void OwlModemNetwork::setHandlerEPSRegistrationURC(OwlModem_EPSRegistrationStatu
 static str s_csq = STRDECL("+CSQ: ");
 
 int OwlModemNetwork::getSignalQuality(at_csq_rssi_e *out_rssi, at_csq_qual_e *out_qual) {
-  int cnt                 = 0;
-  str token               = {0};
-  char save               = 0;
+  int cnt   = 0;
+  str token = {0};
+  char save = 0;
   if (out_rssi) *out_rssi = AT_CSQ__RSSI__Not_Known_or_Detectable_99;
   if (out_qual) *out_qual = AT_CSQ__Qual__Not_Known_or_Not_Detectable;
-  int result =
-      atModem_->doCommandBlocking("AT+CSQ", 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) == AT_Result_Code__OK;
+  int result = atModem_->doCommandBlocking("AT+CSQ", 1000, &network_response, MODEM_NETWORK_RESPONSE_BUFFER_SIZE) ==
+               AT_Result_Code__OK;
   if (!result) return 0;
   OwlModemAT::filterResponse(s_csq, &network_response);
   while (str_tok(network_response, ",", &token)) {

--- a/src/BreakoutSDK/modem/OwlModemNetwork.h
+++ b/src/BreakoutSDK/modem/OwlModemNetwork.h
@@ -26,6 +26,8 @@
 
 #include "enums.h"
 
+#include "OwlModemAT.h"
+
 
 #define MODEM_NETWORK_RESPONSE_BUFFER_SIZE 512
 
@@ -64,16 +66,12 @@ typedef void (*OwlModem_EPSRegistrationStatusChangeHandler_f)(at_cereg_stat_e st
                                                               uint32_t reject_cause);
 
 
-
-class OwlModem;
-
-
 /**
  * Twilio wrapper for the AT serial interface to a modem - Methods to get information from the Network card
  */
 class OwlModemNetwork {
  public:
-  OwlModemNetwork(OwlModem *owlModem);
+  OwlModemNetwork(OwlModemAT *atModem);
 
   /**
    * Handler for Unsolicited Response Codes from the modem - called from OwlModem on timer, when URC is received
@@ -81,7 +79,7 @@ class OwlModemNetwork {
    * @param data - data of the event
    * @return 1 if the line was handled, 0 if no match here
    */
-  int processURC(str urc, str data);
+  static int processURC(str urc, str data, void* instance);
 
 
 
@@ -263,7 +261,7 @@ class OwlModemNetwork {
 
 
  private:
-  OwlModem *owlModem = 0;
+  OwlModemAT *atModem_ = 0;
 
   char network_response_buffer[MODEM_NETWORK_RESPONSE_BUFFER_SIZE];
   str network_response = {.s = network_response_buffer, .len = 0};

--- a/src/BreakoutSDK/modem/OwlModemNetwork.h
+++ b/src/BreakoutSDK/modem/OwlModemNetwork.h
@@ -79,7 +79,7 @@ class OwlModemNetwork {
    * @param data - data of the event
    * @return 1 if the line was handled, 0 if no match here
    */
-  static int processURC(str urc, str data, void* instance);
+  static int processURC(str urc, str data, void *instance);
 
 
 

--- a/src/BreakoutSDK/modem/OwlModemPDN.cpp
+++ b/src/BreakoutSDK/modem/OwlModemPDN.cpp
@@ -29,7 +29,7 @@
 
 
 
-OwlModemPDN::OwlModemPDN(OwlModem *owlModem) : owlModem(owlModem) {
+OwlModemPDN::OwlModemPDN(OwlModemAT *atModem) : atModem_(atModem) {
 }
 
 
@@ -43,9 +43,9 @@ int OwlModemPDN::getAPNIPAddress(uint8_t cid, uint8_t ipv4[4], uint8_t ipv6[16])
   if (ipv6) bzero(ipv6, 16);
   char buf[64];
   snprintf(buf, 64, "AT+CGPADDR=%d", cid);
-  int result = owlModem->doCommand(buf, 3000, &pdn_response, MODEM_PDN_RESPONSE_BUFFER_SIZE) == AT_Result_Code__OK;
+  int result = atModem_->doCommandBlocking(buf, 3000, &pdn_response, MODEM_PDN_RESPONSE_BUFFER_SIZE) == AT_Result_Code__OK;
   if (!result) return 0;
-  owlModem->filterResponse(s_cgpaddr, &pdn_response);
+  OwlModemAT::filterResponse(s_cgpaddr, &pdn_response);
   while (str_tok(pdn_response, ",\r\n", &token)) {
     str token_ip = {0};
     switch (cnt) {

--- a/src/BreakoutSDK/modem/OwlModemPDN.cpp
+++ b/src/BreakoutSDK/modem/OwlModemPDN.cpp
@@ -43,7 +43,8 @@ int OwlModemPDN::getAPNIPAddress(uint8_t cid, uint8_t ipv4[4], uint8_t ipv6[16])
   if (ipv6) bzero(ipv6, 16);
   char buf[64];
   snprintf(buf, 64, "AT+CGPADDR=%d", cid);
-  int result = atModem_->doCommandBlocking(buf, 3000, &pdn_response, MODEM_PDN_RESPONSE_BUFFER_SIZE) == AT_Result_Code__OK;
+  int result =
+      atModem_->doCommandBlocking(buf, 3000, &pdn_response, MODEM_PDN_RESPONSE_BUFFER_SIZE) == AT_Result_Code__OK;
   if (!result) return 0;
   OwlModemAT::filterResponse(s_cgpaddr, &pdn_response);
   while (str_tok(pdn_response, ",\r\n", &token)) {

--- a/src/BreakoutSDK/modem/OwlModemPDN.h
+++ b/src/BreakoutSDK/modem/OwlModemPDN.h
@@ -25,13 +25,11 @@
 #define __OWL_MODEM_PDN_H__
 
 #include "enums.h"
+#include "OwlModemAT.h"
 
 
 
 #define MODEM_PDN_RESPONSE_BUFFER_SIZE 512
-
-
-class OwlModem;
 
 
 /**
@@ -39,7 +37,7 @@ class OwlModem;
  */
 class OwlModemPDN {
  public:
-  OwlModemPDN(OwlModem *owlModem);
+  OwlModemPDN(OwlModemAT *atModem);
 
 
   // TODO
@@ -69,7 +67,7 @@ class OwlModemPDN {
 
 
  private:
-  OwlModem *owlModem = 0;
+  OwlModemAT *atModem_ = 0;
 
   char pdn_response_buffer[MODEM_PDN_RESPONSE_BUFFER_SIZE];
   str pdn_response = {.s = pdn_response_buffer, .len = 0};

--- a/src/BreakoutSDK/modem/OwlModemSIM.cpp
+++ b/src/BreakoutSDK/modem/OwlModemSIM.cpp
@@ -30,8 +30,8 @@
 
 
 OwlModemSIM::OwlModemSIM(OwlModemAT *atModem) : atModem_(atModem) {
-  if(atModem_ != nullptr) {
-    atModem_-> registerUrcHandler(OwlModemSIM::processURC, this);
+  if (atModem_ != nullptr) {
+    atModem_->registerUrcHandler(OwlModemSIM::processURC, this);
   }
 }
 
@@ -52,8 +52,8 @@ int OwlModemSIM::handleCPIN(str urc, str data) {
   return 1;
 }
 
-int OwlModemSIM::processURC(str urc, str data, void* instance) {
-  OwlModemSIM *inst = reinterpret_cast<OwlModemSIM*>(instance);
+int OwlModemSIM::processURC(str urc, str data, void *instance) {
+  OwlModemSIM *inst = reinterpret_cast<OwlModemSIM *>(instance);
   if (inst->handleCPIN(urc, data)) return 1;
   return 0;
 }
@@ -72,7 +72,6 @@ int OwlModemSIM::getICCID(str *out_response, int max_response_len) {
 int OwlModemSIM::getIMSI(str *out_response, int max_response_len) {
   if (out_response) out_response->len = 0;
   return atModem_->doCommandBlocking("AT+CIMI", 1000, out_response, max_response_len) == AT_Result_Code__OK;
-
 }
 
 static str s_cnum = STRDECL("+CNUM: ");

--- a/src/BreakoutSDK/modem/OwlModemSIM.h
+++ b/src/BreakoutSDK/modem/OwlModemSIM.h
@@ -25,6 +25,7 @@
 #define __OWL_MODEM_SIM_H__
 
 #include "enums.h"
+#include "OwlModemAT.h"
 
 
 
@@ -38,15 +39,13 @@ typedef void (*OwlModem_PINHandler_f)(str message);
 
 
 
-class OwlModem;
-
 
 /**
  * Twilio wrapper for the AT serial interface to a modem - Methods to get information from the SIM card
  */
 class OwlModemSIM {
  public:
-  OwlModemSIM(OwlModem *owlModem);
+  OwlModemSIM(OwlModemAT *atModem);
 
   /**
    * Handler for Unsolicited Response Codes from the modem - called from OwlModem on timer, when URC is received
@@ -54,7 +53,7 @@ class OwlModemSIM {
    * @param data - data of the event
    * @return 1 if the line was handled, 0 if no match here
    */
-  int processURC(str urc, str data);
+  static int processURC(str urc, str data, void* instance);
 
 
 
@@ -123,7 +122,7 @@ class OwlModemSIM {
   OwlModem_PINHandler_f handler_cpin = 0;
 
  private:
-  OwlModem *owlModem = 0;
+  OwlModemAT *atModem_ = 0;
 
   //char sim_response_buffer[MODEM_SIM_RESPONSE_BUFFER_SIZE];
   //str sim_response = {.s = sim_response_buffer, .len = 0};

--- a/src/BreakoutSDK/modem/OwlModemSIM.h
+++ b/src/BreakoutSDK/modem/OwlModemSIM.h
@@ -39,7 +39,6 @@ typedef void (*OwlModem_PINHandler_f)(str message);
 
 
 
-
 /**
  * Twilio wrapper for the AT serial interface to a modem - Methods to get information from the SIM card
  */
@@ -53,7 +52,7 @@ class OwlModemSIM {
    * @param data - data of the event
    * @return 1 if the line was handled, 0 if no match here
    */
-  static int processURC(str urc, str data, void* instance);
+  static int processURC(str urc, str data, void *instance);
 
 
 
@@ -124,8 +123,8 @@ class OwlModemSIM {
  private:
   OwlModemAT *atModem_ = 0;
 
-  //char sim_response_buffer[MODEM_SIM_RESPONSE_BUFFER_SIZE];
-  //str sim_response = {.s = sim_response_buffer, .len = 0};
+  // char sim_response_buffer[MODEM_SIM_RESPONSE_BUFFER_SIZE];
+  // str sim_response = {.s = sim_response_buffer, .len = 0};
 
   int handleCPIN(str urc, str data);
 };

--- a/src/BreakoutSDK/modem/OwlModemSocket.cpp
+++ b/src/BreakoutSDK/modem/OwlModemSocket.cpp
@@ -60,11 +60,13 @@ void OwlModemSocketStatus::setClosed() {
   handler_SocketClosed = 0;
 }
 
-
-
 OwlModemSocket::OwlModemSocket(OwlModemAT *atModem) : atModem_(atModem) {
   for (uint8_t socket = 0; socket < MODEM_MAX_SOCKETS; socket++)
     status[socket].setClosed();
+
+  if (atModem_ != nullptr) {
+    atModem_->registerUrcHandler(OwlModemSocket::processURC, this);
+  }
 }
 
 

--- a/src/BreakoutSDK/modem/OwlModemSocket.cpp
+++ b/src/BreakoutSDK/modem/OwlModemSocket.cpp
@@ -261,8 +261,8 @@ int OwlModemSocket::processURCReceiveFrom(str urc, str data) {
 }
 
 
-int OwlModemSocket::processURC(str urc, str data, void* instance) {
-  OwlModemSocket *inst = reinterpret_cast<OwlModemSocket*>(instance);
+int OwlModemSocket::processURC(str urc, str data, void *instance) {
+  OwlModemSocket *inst = reinterpret_cast<OwlModemSocket *>(instance);
 
   /* ordered based on the expected frequency of arrival */
   if (inst->processURCReceiveFrom(urc, data)) return 1;
@@ -279,7 +279,7 @@ void OwlModemSocket::handleWaitingData() {
   LOG(L_MEM, "Starting handleWaitingData\r\n");
 
   char buf[64];
-  str remote_ip = {.s = buf, .len = 0};
+  str remote_ip        = {.s = buf, .len = 0};
   uint16_t remote_port = 0;
   int data_len         = 0;
 
@@ -363,14 +363,14 @@ static str s_usocr = STRDECL("+USOCR: ");
 
 int OwlModemSocket::open(at_uso_protocol_e protocol, uint16_t local_port, uint8_t *out_socket) {
   if (out_socket) *out_socket = 255;
-  int socket                  = 255;
+  int socket = 255;
   char buf[64];
   snprintf(buf, 64, "AT+USOCR=%d,%u", protocol, local_port);
   int result =
       atModem_->doCommandBlocking(buf, 3000, &socket_response, MODEM_SOCKET_RESPONSE_BUFFER_SIZE) == AT_Result_Code__OK;
   if (!result) return 0;
   OwlModemAT::filterResponse(s_usocr, &socket_response);
-  socket                      = str_to_uint32_t(socket_response, 10);
+  socket = str_to_uint32_t(socket_response, 10);
   if (out_socket) *out_socket = socket;
 
   this->status[socket].setOpened(protocol);
@@ -437,8 +437,8 @@ int OwlModemSocket::connect(uint8_t socket, str remote_ip, uint16_t remote_port,
       LOG(L_ERR, "Socket %d has unsupported protocol %d\r\n", this->status[socket].protocol);
       return 0;
   }
-  int result =
-      atModem_->doCommandBlocking(buf, 120 * 1000, &socket_response, MODEM_SOCKET_RESPONSE_BUFFER_SIZE) == AT_Result_Code__OK;
+  int result = atModem_->doCommandBlocking(buf, 120 * 1000, &socket_response, MODEM_SOCKET_RESPONSE_BUFFER_SIZE) ==
+               AT_Result_Code__OK;
   if (!result) return 0;
   this->status[socket].is_connected         = 1;
   this->status[socket].handler_SocketClosed = cb;
@@ -454,8 +454,8 @@ int OwlModemSocket::send(uint8_t socket, str data) {
   len += str_to_hex(buf + len, 1200 - len, data);
   buf[len++] = '\"';
   buf[len++] = 0;
-  int result =
-      atModem_->doCommandBlocking(buf, 120 * 1000, &socket_response, MODEM_SOCKET_RESPONSE_BUFFER_SIZE) == AT_Result_Code__OK;
+  int result = atModem_->doCommandBlocking(buf, 120 * 1000, &socket_response, MODEM_SOCKET_RESPONSE_BUFFER_SIZE) ==
+               AT_Result_Code__OK;
   if (!result) return -1;
   OwlModemAT::filterResponse(s_usowr, &socket_response);
   str token = {0};
@@ -494,7 +494,7 @@ int OwlModemSocket::sendUDP(uint8_t socket, str data, int *out_bytes_sent) {
     LOG(L_ERR, "Socket %d is not an UDP socket\r\n", socket);
     return 0;
   }
-  int bytes_sent                      = this->send(socket, data);
+  int bytes_sent = this->send(socket, data);
   if (out_bytes_sent) *out_bytes_sent = bytes_sent;
   LOG(L_INFO, "Sent data over UDP on socket %u %d bytes\r\n", socket, bytes_sent);
   return bytes_sent == data.len;
@@ -521,7 +521,7 @@ int OwlModemSocket::sendTCP(uint8_t socket, str data, int *out_bytes_sent) {
     LOG(L_ERR, "Socket %d is not an TCP socket\r\n", socket);
     return 0;
   }
-  int bytes_sent                      = this->send(socket, data);
+  int bytes_sent = this->send(socket, data);
   if (out_bytes_sent) *out_bytes_sent = bytes_sent;
   LOG(L_INFO, "Sent data over TCP on socket %u %d bytes\r\n", socket, bytes_sent);
   return bytes_sent > 0;
@@ -553,8 +553,8 @@ int OwlModemSocket::sendToUDP(uint8_t socket, str remote_ip, uint16_t remote_por
   len += str_to_hex(buf + len, 1200 - len, data);
   buf[len++] = '\"';
   buf[len++] = 0;
-  int result =
-      atModem_->doCommandBlocking(buf, 10 * 1000, &socket_response, MODEM_SOCKET_RESPONSE_BUFFER_SIZE) == AT_Result_Code__OK;
+  int result = atModem_->doCommandBlocking(buf, 10 * 1000, &socket_response, MODEM_SOCKET_RESPONSE_BUFFER_SIZE) ==
+               AT_Result_Code__OK;
   if (!result) return 0;
   OwlModemAT::filterResponse(s_usost, &socket_response);
   str token = {0};
@@ -575,8 +575,8 @@ int OwlModemSocket::sendToUDP(uint8_t socket, str remote_ip, uint16_t remote_por
 
 int OwlModemSocket::getQueuedForReceive(uint8_t socket, int *out_receive_tcp, int *out_receive_udp,
                                         int *out_receivefrom_udp) {
-  if (out_receive_tcp) *out_receive_tcp         = 0;
-  if (out_receive_udp) *out_receive_udp         = 0;
+  if (out_receive_tcp) *out_receive_tcp = 0;
+  if (out_receive_udp) *out_receive_udp = 0;
   if (out_receivefrom_udp) *out_receivefrom_udp = 0;
   if (socket >= MODEM_MAX_SOCKETS) {
     LOG(L_ERR, "Bad socket %d >= %d\r\n", socket);
@@ -587,7 +587,7 @@ int OwlModemSocket::getQueuedForReceive(uint8_t socket, int *out_receive_tcp, in
       if (out_receive_tcp) *out_receive_tcp = status[socket].len_outstanding_receive_data;
       break;
     case AT_USO_Protocol__UDP:
-      if (out_receive_udp) *out_receive_udp         = status[socket].len_outstanding_receive_data;
+      if (out_receive_udp) *out_receive_udp = status[socket].len_outstanding_receive_data;
       if (out_receivefrom_udp) *out_receivefrom_udp = status[socket].len_outstanding_receivefrom_data;
       break;
     default:
@@ -709,7 +709,7 @@ int OwlModemSocket::receiveFromUDP(uint8_t socket, uint16_t len, str *out_remote
                                    str *out_data, int max_data_len) {
   if (out_remote_ip) out_remote_ip->len = 0;
   if (out_remote_port) *out_remote_port = 0;
-  if (out_data) out_data->len           = 0;
+  if (out_data) out_data->len = 0;
   if (socket >= MODEM_MAX_SOCKETS) {
     LOG(L_ERR, "Bad socket %d >= %d\r\n", socket);
     return 0;
@@ -861,7 +861,7 @@ int OwlModemSocket::acceptTCP(uint8_t socket, uint16_t local_port, OwlModem_TCPA
 
 int OwlModemSocket::openListenUDP(uint16_t local_port, OwlModem_UDPDataHandler_f handler_data, uint8_t *out_socket) {
   if (out_socket) *out_socket = 255;
-  uint8_t socket              = 255;
+  uint8_t socket = 255;
 
   if (!this->open(AT_USO_Protocol__UDP, 0, &socket)) goto error;
   if (!this->listenUDP(socket, local_port, handler_data)) goto error;
@@ -876,7 +876,7 @@ error:
 int OwlModemSocket::openConnectUDP(str remote_ip, uint16_t remote_port, OwlModem_UDPDataHandler_f handler_data,
                                    uint8_t *out_socket) {
   if (out_socket) *out_socket = 255;
-  uint8_t socket              = 255;
+  uint8_t socket = 255;
 
   if (!this->open(AT_USO_Protocol__UDP, 0, &socket)) goto error;
   if (!this->connect(socket, remote_ip, remote_port, (OwlModem_SocketClosedHandler_f)0)) goto error;
@@ -893,7 +893,7 @@ error:
 int OwlModemSocket::openListenConnectUDP(uint16_t local_port, str remote_ip, uint16_t remote_port,
                                          OwlModem_UDPDataHandler_f handler_data, uint8_t *out_socket) {
   if (out_socket) *out_socket = 255;
-  uint8_t socket              = 255;
+  uint8_t socket = 255;
 
   if (!this->open(AT_USO_Protocol__UDP, 0, &socket)) goto error;
   if (!this->listenUDP(socket, local_port, handler_data)) goto error;
@@ -910,7 +910,7 @@ int OwlModemSocket::openListenConnectTCP(uint16_t local_port, str remote_ip, uin
                                          OwlModem_SocketClosedHandler_f handler_close,
                                          OwlModem_TCPDataHandler_f handler_data, uint8_t *out_socket) {
   if (out_socket) *out_socket = 255;
-  uint8_t socket              = 255;
+  uint8_t socket = 255;
 
   if (!this->open(AT_USO_Protocol__TCP, local_port, &socket)) goto error;
   if (!this->listenTCP(socket, local_port, handler_data)) goto error;
@@ -927,7 +927,7 @@ int OwlModemSocket::openAcceptTCP(uint16_t local_port, OwlModem_TCPAcceptHandler
                                   OwlModem_SocketClosedHandler_f handler_socket_close,
                                   OwlModem_TCPDataHandler_f handler_data, uint8_t *out_socket) {
   if (out_socket) *out_socket = 255;
-  uint8_t socket              = 255;
+  uint8_t socket = 255;
 
   if (!this->open(AT_USO_Protocol__TCP, 0, &socket)) goto error;
   if (!this->listenTCP(socket, local_port, handler_data)) goto error;

--- a/src/BreakoutSDK/modem/OwlModemSocket.h
+++ b/src/BreakoutSDK/modem/OwlModemSocket.h
@@ -25,6 +25,7 @@
 #define __OWL_MODEM_SOCKET_H__
 
 #include "enums.h"
+#include "OwlModemAT.h"
 
 
 
@@ -103,15 +104,16 @@ class OwlModem;
  */
 class OwlModemSocket {
  public:
-  OwlModemSocket(OwlModem *owlModem);
+  OwlModemSocket(OwlModemAT *atModem);
 
   /**
    * Handler for Unsolicited Response Codes from the modem - called from OwlModem on timer, when URC is received
    * @param urc - event id
    * @param data - data of the event
+   * @param instance - pointer to OwlModemSocket instance
    * @return 1 if the line was handled, 0 if no match here
    */
-  int processURC(str urc, str data);
+  static int processURC(str urc, str data, void* instance);
 
   /**
    * Handler for incoming data - triggers receive and handler calling for UDP/TCP queued packets.
@@ -322,7 +324,7 @@ class OwlModemSocket {
 
 
  private:
-  OwlModem *owlModem = 0;
+  OwlModemAT *atModem_ = 0;
 
 
   OwlModemSocketStatus status[MODEM_MAX_SOCKETS];

--- a/src/BreakoutSDK/modem/OwlModemSocket.h
+++ b/src/BreakoutSDK/modem/OwlModemSocket.h
@@ -113,7 +113,7 @@ class OwlModemSocket {
    * @param instance - pointer to OwlModemSocket instance
    * @return 1 if the line was handled, 0 if no match here
    */
-  static int processURC(str urc, str data, void* instance);
+  static int processURC(str urc, str data, void *instance);
 
   /**
    * Handler for incoming data - triggers receive and handler calling for UDP/TCP queued packets.

--- a/src/BreakoutSDK/modem/enums.h
+++ b/src/BreakoutSDK/modem/enums.h
@@ -68,9 +68,8 @@ typedef enum {
   AT_CFUN__FUN__Modem_Silent_Reset__With_SIM_Reset =
       16, /**< only for SARA-R4/N4 series - with detach from network and saving of NVM parameters */
   AT_CFUN__FUN__Minimum_Functionality_with_CS_PS_and_SIM_Deactivated = 19, /**< only for SARA-R4/N4 series */
-  AT_CFUN__FUN__Modem_Deep_Low_Power_Mode =
-      127, /**< only for SARA-R4/N4 series - with detach from network and saving of NVM
-         parameters; wake up with power cycle or module reset */
+  AT_CFUN__FUN__Modem_Deep_Low_Power_Mode = 127, /**< only for SARA-R4/N4 series - with detach from network and saving
+                                               of NVM parameters; wake up with power cycle or module reset */
 } at_cfun_fun_e;
 
 char *at_cfun_fun_text(at_cfun_fun_e code);

--- a/src/BreakoutSDK/modem/enums.h
+++ b/src/BreakoutSDK/modem/enums.h
@@ -33,6 +33,7 @@
 
 
 typedef enum {
+  AT_Result_Code__in_progress  = -5,
   AT_Result_Code__cme_error    = -4,
   AT_Result_Code__failure      = -3,
   AT_Result_Code__timeout      = -2,

--- a/src/BreakoutSDK/utils/bin_t.h
+++ b/src/BreakoutSDK/utils/bin_t.h
@@ -92,7 +92,7 @@ typedef struct {
       LOG(L_CRIT, "Not implemented for %d > 8 bytes\r\n", _width_);                                                    \
       goto error;                                                                                                      \
     }                                                                                                                  \
-    for (int i               = (_width_)-1; i >= 0; i--)                                                               \
+    for (int i = (_width_)-1; i >= 0; i--)                                                                             \
       (_b_)->s[(_b_)->idx++] = (_uint_ >> (i * 8)) & 0xFF;                                                             \
   } while (0)
 

--- a/src/BreakoutSDK/utils/lists.h
+++ b/src/BreakoutSDK/utils/lists.h
@@ -164,7 +164,7 @@
       ((list)->head)->prev = (add);                                                                                    \
     else                                                                                                               \
       (list)->tail = (add);                                                                                            \
-    (list)->head   = (add);                                                                                            \
+    (list)->head = (add);                                                                                              \
   } while (0)
 
 #define WL_APPEND(list, add)                                                                                           \
@@ -175,17 +175,17 @@
       ((list)->tail)->next = (add);                                                                                    \
     else                                                                                                               \
       (list)->head = (add);                                                                                            \
-    (list)->tail   = (add);                                                                                            \
+    (list)->tail = (add);                                                                                              \
   } while (0)
 
 #define WL_APPEND_LIST(list, add_list)                                                                                 \
   do {                                                                                                                 \
-    if (!(list)->head) (list)->head              = (add_list)->head;                                                   \
+    if (!(list)->head) (list)->head = (add_list)->head;                                                                \
     if ((add_list)->head) (add_list)->head->prev = (list)->tail;                                                       \
-    if ((list)->tail) (list)->tail->next         = (add_list)->head;                                                   \
-    (list)->tail                                 = (add_list)->tail;                                                   \
-    (add_list)->head                             = 0;                                                                  \
-    (add_list)->tail                             = 0;                                                                  \
+    if ((list)->tail) (list)->tail->next = (add_list)->head;                                                           \
+    (list)->tail     = (add_list)->tail;                                                                               \
+    (add_list)->head = 0;                                                                                              \
+    (add_list)->tail = 0;                                                                                              \
   } while (0)
 
 /**
@@ -203,7 +203,7 @@
         (list)->head = (add);                                                                                          \
       else                                                                                                             \
         el_is->prev->next = (add);                                                                                     \
-      el_is->prev         = (add);                                                                                     \
+      el_is->prev = (add);                                                                                             \
     } else {                                                                                                           \
       (add)->next = NULL;                                                                                              \
       (add)->prev = (list)->tail;                                                                                      \
@@ -211,7 +211,7 @@
         ((list)->tail)->next = (add);                                                                                  \
       else                                                                                                             \
         (list)->head = (add);                                                                                          \
-      (list)->tail   = (add);                                                                                          \
+      (list)->tail = (add);                                                                                            \
     }                                                                                                                  \
   } while (0)
 
@@ -228,8 +228,8 @@
       ((del)->next)->prev = (del)->prev;                                                                               \
     else                                                                                                               \
       ((list)->tail) = (del)->prev;                                                                                    \
-    (del)->next      = 0;                                                                                              \
-    (del)->prev      = 0;                                                                                              \
+    (del)->next = 0;                                                                                                   \
+    (del)->prev = 0;                                                                                                   \
   } while (0)
 
 #define WL_FOREACH(list, el) for ((el) = (list)->head; (el); (el) = (el)->next)

--- a/src/BreakoutSDK/utils/time.cpp
+++ b/src/BreakoutSDK/utils/time.cpp
@@ -35,3 +35,7 @@ extern "C" owl_time_t owl_time() {
   if (now < last_millis) epoch++;
   return (uint64_t)epoch << 32 | now;
 }
+
+extern "C" void owl_delay(uint32_t ms) {
+  delay(ms);
+}

--- a/src/BreakoutSDK/utils/time.h
+++ b/src/BreakoutSDK/utils/time.h
@@ -42,6 +42,8 @@ typedef uint64_t owl_time_t;
  */
 owl_time_t owl_time();
 
+void owl_delay(uint32_t ms);
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
First iteration of refactoring. Major change: general logic for AT commands moved to `OwlModemAT`. `OwlModem` class is now the only one containing Seeed/Arduino specific code in `modem` directory.